### PR TITLE
Fix RHEL 7 does not have openvpn-auth-ldap package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,12 +28,12 @@ class openvpn::params {
         # http://docs.puppetlabs.com/references/latest/function.html#versioncmp
         if(versioncmp($::operatingsystemrelease, '6.4') < 0) { # Version < 6.4
           $easyrsa_source = '/usr/share/openvpn/easy-rsa/2.0'
-        } elsif(versioncmp($::operatingsystemrelease, '6.4') < 0) and
+        } elsif(versioncmp($::operatingsystemrelease, '6.4') > 0) and
           (versioncmp($::operatingsystemrelease, '7.0') < 0) { # Version >= 6.4 < 7.0
           $additional_packages = ['easy-rsa', 'openvpn-auth-ldap']
           $easyrsa_source = '/usr/share/easy-rsa/2.0'
           $ldap_auth_plugin_location = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-ldap.so'
-        } else { # Version >= 6.4 < 7.0
+        } else { # Version >= 7.0
           $additional_packages = ['easy-rsa']
           $easyrsa_source = '/usr/share/easy-rsa/2.0'
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,10 +28,14 @@ class openvpn::params {
         # http://docs.puppetlabs.com/references/latest/function.html#versioncmp
         if(versioncmp($::operatingsystemrelease, '6.4') < 0) { # Version < 6.4
           $easyrsa_source = '/usr/share/openvpn/easy-rsa/2.0'
-        } else { # Version >= 6.4
+        } elsif(versioncmp($::operatingsystemrelease, '6.4') < 0) and
+          (versioncmp($::operatingsystemrelease, '7.0') < 0) { # Version >= 6.4 < 7.0
           $additional_packages = ['easy-rsa', 'openvpn-auth-ldap']
           $easyrsa_source = '/usr/share/easy-rsa/2.0'
           $ldap_auth_plugin_location = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-ldap.so'
+        } else { # Version >= 6.4 < 7.0
+          $additional_packages = ['easy-rsa']
+          $easyrsa_source = '/usr/share/easy-rsa/2.0'
         }
       } else { # Redhat/CentOS < 6
         $easyrsa_source = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'


### PR DESCRIPTION
At the moment there is no openvpn-auth-ldap package under rhel 7
This fix allow the module to still install, though obviously the ldap feature won't be available