### PR TITLE
Don't put the cipher key in if no cipher is specified.

### DIFF
--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -111,4 +111,10 @@ describe 'openvpn::client', :type => :define do
     it { should contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^sndbuf\s+393216$/)}
     it { should contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^rcvbuf\s+393215$/)}
   end
+
+  context "omitting the cipher key" do
+    let(:params) { { 'server' => 'test_server' } }
+    it { should_not contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^cipher/) }
+  end
+
 end

--- a/templates/client.erb
+++ b/templates/client.erb
@@ -19,9 +19,9 @@ persist-key
 <% if @persist_tun -%>
 persist-tun
 <% end -%>
-<% if @cipher  -%>
+<% if @cipher != '' -%>
 cipher <%= @cipher %>
-<% end %>
+<% end -%>
 <% if @mute_replay_warnings -%>
 mute-replay-warnings
 <% end -%>


### PR DESCRIPTION
If no cipher is specified in puppet, the client configuration files get written with a cipher key but no value. This causes the android openvpn app to complain.

I envisage 3 possible solutions, of which this PR implements the most simple:
- Copy server.erb and only write the cipher if it not empty
- Default the cipher to a strong cipher ie AES-256-CBC
- Default the cipher to undef so it does not get written with the template file in its current state.

It's also worth noting that server.erb and client.erb should probably implement similar variable checking and standardising on one or other solution. 