### PR TITLE
Add TLS and x509-name verification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Puppet module to manage OpenVPN servers
 * Support for multiple server instances
 * Support for LDAP-Authentication
 * Support for server instance in client mode
+* Support for TLS
 
 ## Supported OS
 

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -103,7 +103,7 @@ define openvpn::ca(
   $key_cn = '',
   $key_name = '',
   $key_ou = '',
-  $tls_auth = 'false',
+  $tls_auth = false,
 ) {
 
   include openvpn
@@ -180,15 +180,6 @@ define openvpn::ca(
     require  => Exec["initca ${name}"],
   }
 
-  if $tls_auth {
-    exec { "generate tls key for ${name}":
-      command  => "openvpn --genkey --secret keys/ta.key",
-      cwd      => "/etc/openvpn/${name}/easy-rsa",
-      creates  => "/etc/openvpn/${name}/easy-rsa/keys/ta.key",
-      provider => 'shell',
-      require => Exec["copy easy-rsa to openvpn config folder ${name}"],
-    }
-  }
   file { "/etc/openvpn/${name}/keys":
     ensure  => link,
     target  => "/etc/openvpn/${name}/easy-rsa/keys",
@@ -207,6 +198,15 @@ define openvpn::ca(
     creates  => "/etc/openvpn/${name}/crl.pem",
     provider => 'shell',
     require  => Exec["generate server cert ${name}"],
+  }
+  if $tls_auth {
+    exec { "generate tls key for ${name}":
+      command  => "openvpn --genkey --secret keys/ta.key",
+      cwd      => "/etc/openvpn/${name}/easy-rsa",
+      creates  => "/etc/openvpn/${name}/easy-rsa/keys/ta.key",
+      provider => 'shell',
+      require  => Exec["generate server cert ${name}"],
+    }
   }
 
   file { "/etc/openvpn/${name}/easy-rsa/keys/crl.pem":

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -54,6 +54,10 @@
 #     and KEY_CN in vars
 #   Default: None
 #
+# [*tls_auth*]
+#   Boolean. Determins if a tls key is generated
+#   Default: False
+#
 # === Examples
 #
 #   openvpn::ca {
@@ -99,6 +103,7 @@ define openvpn::ca(
   $key_cn = '',
   $key_name = '',
   $key_ou = '',
+  $tls_auth = 'false',
 ) {
 
   include openvpn
@@ -175,6 +180,15 @@ define openvpn::ca(
     require  => Exec["initca ${name}"],
   }
 
+  if $tls_auth {
+    exec { "generate tls key for ${name}":
+      command  => "openvpn --genkey --secret keys/ta.key",
+      cwd      => "/etc/openvpn/${name}/easy-rsa",
+      creates  => "/etc/openvpn/${name}/easy-rsa/keys/ta.key",
+      provider => 'shell',
+      require => Exec["copy easy-rsa to openvpn config folder ${name}"],
+    }
+  }
   file { "/etc/openvpn/${name}/keys":
     ensure  => link,
     target  => "/etc/openvpn/${name}/easy-rsa/keys",

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -84,8 +84,8 @@
 #   Default: false
 #
 # [*tls_auth*]
-#   Boolean. Activates tls-auth to Add an additional layer of HMAC 
-#     authentication on top of the TLS control channel to protect 
+#   Boolean. Activates tls-auth to Add an additional layer of HMAC
+#     authentication on top of the TLS control channel to protect
 #     against DoS attacks. This has to be set to the same value as on the
 #     Server
 #   Default: false

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -265,6 +265,12 @@
 #     and KEY_CN in vars
 #   Default: None
 #
+# [*tls_auth*]
+#   Boolean. Activates tls-auth to Add an additional layer of HMAC 
+#     authentication on top of the TLS control channel to protect 
+#     against DoS attacks.
+#   Default: false
+#
 # [*server_poll_timeout*]
 #   Integer. Value for timeout before trying the next server.
 #   Default: undef
@@ -370,6 +376,7 @@ define openvpn::server(
   $cipher = '',
   $persist_key = false,
   $persist_tun = false,
+  $tls_auth = false,
   $server_poll_timeout = undef,
   $ping_timer_rem = false,
 ) {
@@ -429,6 +436,7 @@ define openvpn::server(
       key_cn       => $key_cn,
       key_name     => $key_name,
       key_ou       => $key_ou,
+      tls_auth     => $tls_auth,
     }
   } else {
     # VPN Client Mode

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -266,8 +266,8 @@
 #   Default: None
 #
 # [*tls_auth*]
-#   Boolean. Activates tls-auth to Add an additional layer of HMAC 
-#     authentication on top of the TLS control channel to protect 
+#   Boolean. Activates tls-auth to Add an additional layer of HMAC
+#     authentication on top of the TLS control channel to protect
 #     against DoS attacks.
 #   Default: false
 #

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -271,6 +271,11 @@
 #     against DoS attacks.
 #   Default: false
 #
+# [*tls_server*]
+#   Boolean. If proto not tcp it lets you choose if the parameter
+#     tls-server is set or not.
+#   Default: false
+#
 # [*server_poll_timeout*]
 #   Integer. Value for timeout before trying the next server.
 #   Default: undef
@@ -385,6 +390,7 @@ define openvpn::server(
   $persist_key = false,
   $persist_tun = false,
   $tls_auth = false,
+  $tls_server = false,
   $server_poll_timeout = undef,
   $ping_timer_rem = false,
   $sndbuf = undef,
@@ -396,9 +402,13 @@ define openvpn::server(
   Openvpn::Server[$name] ~>
   Class['openvpn::service']
 
-  $tls_server = $proto ? {
-    /tcp/   => true,
-    default => false
+  if $tls_server {
+    $real_tls_server = $tls_server
+  } else {
+    $real_tls_server = $proto ? {
+      /tcp/   => true,
+      default => false
+    }
   }
 
   $group_to_set = $group ? {

--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -58,6 +58,8 @@ describe 'openvpn::client', :type => :define do
     it { should contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^verb\s+3$/)}
     it { should contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^mute\s+20$/)}
     it { should contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^auth-retry\s+none$/)}
+    it { should_not contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^tls-client$/)}
+    it { should_not contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^verify-x509-name\s+"test_server"\s+name$/)}
   end
 
   context "setting all of the parameters" do
@@ -80,7 +82,7 @@ describe 'openvpn::client', :type => :define do
       'setenv'                => {'CLIENT_CERT' => '0'},
       'setenv_safe'           => {'FORWARD_COMPATIBLE' => '1'},
       'tls_auth'              => true,
-      'x509_name'             => 'test_server'
+      'x509_name'             => 'test_server',
     } }
     let(:facts) { {
       :fqdn           => 'somehost',

--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -78,7 +78,9 @@ describe 'openvpn::client', :type => :define do
       'auth_retry'            => 'interact',
       'verb'                  => '1',
       'setenv'                => {'CLIENT_CERT' => '0'},
-      'setenv_safe'           => {'FORWARD_COMPATIBLE' => '1'}
+      'setenv_safe'           => {'FORWARD_COMPATIBLE' => '1'},
+      'tls_auth'              => true,
+      'x509_name'             => 'test_server'
     } }
     let(:facts) { {
       :fqdn           => 'somehost',
@@ -103,6 +105,8 @@ describe 'openvpn::client', :type => :define do
     it { should contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^setenv\s+CLIENT_CERT\s+0$/)}
     it { should contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^setenv_safe\s+FORWARD_COMPATIBLE\s+1$/)}
     it { should contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^cipher\s+BF-CBC$/)}
+    it { should contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^tls-client$/)}
+    it { should contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(/^verify-x509-name\s+"test_server"\s+name$/)}
   end
 
 end

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -143,6 +143,7 @@ describe 'openvpn::server', :type => :define do
       'persist_key'     => true,
       'persist_tun'     => true,
       'duplicate_cn'    => true,
+      'tls_auth'        => true,
     } }
 
     let(:facts) { {
@@ -189,6 +190,8 @@ describe 'openvpn::server', :type => :define do
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^down "/tmp/down"$}) }
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^script-security 2$}) }
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^duplicate-cn$}) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-server$}) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-auth\s+/etc/openvpn/test_server/keys/ta.key\s+0$}) }
 
     it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/^server-poll-timeout/) }
     it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/^ping-timer-rem/) }
@@ -207,7 +210,8 @@ describe 'openvpn::server', :type => :define do
               :key_expire   => 365,
               :key_cn       => 'yolo',
               :key_name     => 'burp',
-              :key_ou       => 'NSA')
+              :key_ou       => 'NSA',
+              :tls_auth     => true)
     }
 
   end

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -101,7 +101,6 @@ describe 'openvpn::server', :type => :define do
     it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/persist-tun/) }
     it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(%r{^duplicate-cn$}) }
     it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/^ns-cert-type server/) }
-    it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-server$}) }
     it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-auth\s+/etc/openvpn/test_server/keys/ta.key\s+0$}) }
 
   end
@@ -147,6 +146,7 @@ describe 'openvpn::server', :type => :define do
       'persist_tun'     => true,
       'duplicate_cn'    => true,
       'tls_auth'        => true,
+      'tls_server'      => true,
     } }
 
     let(:facts) { {

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -101,6 +101,9 @@ describe 'openvpn::server', :type => :define do
     it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/persist-tun/) }
     it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(%r{^duplicate-cn$}) }
     it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/^ns-cert-type server/) }
+    it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-server$}) }
+    it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-auth\s+/etc/openvpn/test_server/keys/ta.key\s+0$}) }
+
   end
 
   context "creating a server setting all parameters" do

--- a/templates/client.erb
+++ b/templates/client.erb
@@ -46,3 +46,14 @@ up "<%= @up %>"
 <% if @down != '' -%>
 down "<%= @down %>"
 <% end -%>
+<% if @tls_auth -%> 
+
+# tls authentification
+tls-client
+tls-auth keys/<%= @name %>/ta.key 1
+<% end -%>
+<% if @x509_name -%>
+
+# x509 name verification
+verify-x509-name "<%= @x509_name %>" name
+<% end -%>

--- a/templates/client.erb
+++ b/templates/client.erb
@@ -46,7 +46,7 @@ up "<%= @up %>"
 <% if @down != '' -%>
 down "<%= @down %>"
 <% end -%>
-<% if @tls_auth -%> 
+<% if @tls_auth -%>
 
 # tls authentification
 tls-client

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -26,7 +26,7 @@ proto <%= @proto %>-server
 proto <%= @proto %>
 <% end -%>
 port <%= @port %>
-<% if @tls_server -%>
+<% if @real_tls_server -%>
 tls-server
 <% end -%>
 <% if @compression != '' -%>
@@ -129,6 +129,5 @@ ping-timer-rem
 <% if @tls_auth -%>
 
 # tls authentification
-tls-server
 tls-auth /etc/openvpn/<%= @name %>/keys/ta.key 0
 <% end -%>

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -120,3 +120,9 @@ duplicate-cn
 <% if @ping_timer_rem -%>
 ping-timer-rem
 <% end -%>
+<% if @tls_auth -%>
+
+# tls authentification
+tls-server
+tls-auth /etc/openvpn/<%= @name %>/keys/ta.key 0
+<% end -%>


### PR DESCRIPTION
- Server config
  - Added tls-server and tls-auth parameters to server config template
  - Generate TLS key on server while setting up the CA
- Client config
  - Link tls key into client config bundle
  - Added x509-name parameter to client config template
- Added test for tls and x509-name support in client and server