### PR TITLE
added systemd style service name support for RHEL >= 7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,7 +37,6 @@ class openvpn {
   class {'openvpn::params': } ->
   class {'openvpn::install': } ->
   class {'openvpn::config': } ~>
-  class {'openvpn::service': } ->
   Class['openvpn']
 
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -384,10 +384,18 @@ define openvpn::server(
   $rcvbuf = undef,
 ) {
 
+  if(($::osfamily == 'RedHat') and ($::operatingsystemmajrelease >= 7)) {
+    $service_name = "openvpn@${name}"
+  } else {
+    $service_name = "openvpn"
+  }
+
   include openvpn
   Class['openvpn::install'] ->
   Openvpn::Server[$name] ~>
-  Class['openvpn::service']
+  class { 'openvpn::service':
+    service_name = $service_name
+  }
 
   $tls_server = $proto ? {
     /tcp/   => true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,6 +2,11 @@
 #
 # This class maintains the openvpn service.
 #
+# == Parameters
+#
+# [*service_name*]
+#   String. Name of the OpenVPN service to be enabled and started
+#   Default: openvpn
 #
 # === Examples
 #
@@ -29,9 +34,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-class openvpn::service {
+class openvpn::service(
+  $service_name = 'openvpn',
+){
   service {
-    'openvpn':
+    $service_name:
       ensure     => running,
       enable     => true,
       hasrestart => true,


### PR DESCRIPTION
systemd based distributions use the "openvpn@instance" service name format. A switch has been added which detects these systems (currently just RHEL >=7) and adjusts the service name accordingly.

I'm not sure if there is a better place in the module to implement this change as the $name variable is required.

Tested on CentOS7