### PR TITLE
restart service when package updated

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,11 +33,13 @@
 #
 class openvpn::install inherits openvpn::params {
 
-  ensure_packages(['openvpn'])
+  package { 'openvpn':
+    notify => Class['openvpn::service'],
+  }
+
   if $::openvpn::params::additional_packages != undef {
     ensure_packages( any2array($::openvpn::params::additional_packages) )
   }
-
 
   file {
     [ '/etc/openvpn', '/etc/openvpn/keys' ]:


### PR DESCRIPTION
ensure_packages is nice when you're dealing with a common package (such as git) that may be declared elsewhere.  It seems unlikely the openvpn package would be defined elsewhere (in a good config), but restarting the service when the package is updated is important.