### PR TITLE
support systemd-based distros

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,8 +36,14 @@ class openvpn {
 
   class {'openvpn::params': } ->
   class {'openvpn::install': } ->
-  class {'openvpn::config': } ~>
-  class {'openvpn::service': } ->
+  class {'openvpn::config': } ->
   Class['openvpn']
+
+  if ! $::openvpn::params::systemd {
+    class {'openvpn::service':
+      subscribe => [Class['openvpn::config'], Class['openvpn::install'] ],
+      before    => Class['openvpn'],
+    }
+  }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,11 @@ class openvpn::params {
 
       $ldap_auth_plugin_location = undef # no ldap plugin on redhat/centos
 
+      if(versioncmp($::operatingsystemrelease, '7.0') >= 0) {
+        $systemd = true
+      } else {
+        $systemd = false
+      }
     }
     'Debian': { # Debian/Ubuntu
       case $::lsbdistid {
@@ -72,6 +77,8 @@ class openvpn::params {
           fail("Not supported OS / Distribution: ${::osfamily}/${::lsbdistid}")
         }
       }
+
+      $systemd = false
     }
     default: {
       fail("Not supported OS family ${::osfamily}")

--- a/spec/classes/openvpn_init_spec.rb
+++ b/spec/classes/openvpn_init_spec.rb
@@ -2,13 +2,27 @@ require 'spec_helper'
 
 describe 'openvpn', :type => :class do
 
-  let(:facts) { {
-    :concat_basedir => '/var/lib/puppet/concat',
-    :osfamily       => 'Debian',
-    :lsbdistid      => 'Ubuntu',
-    :lsbdistrelease => '12.04',
-  } }
+  context 'non-systemd systems' do
+    let(:facts) { {
+      :concat_basedir => '/var/lib/puppet/concat',
+      :osfamily       => 'Debian',
+      :lsbdistid      => 'Ubuntu',
+      :lsbdistrelease => '12.04',
+    } }
 
-  it { should create_class('openvpn') }
+    it { should create_class('openvpn') }
+    it { should contain_class('openvpn::service') }
+  end
+
+  context 'systemd systems' do
+    let(:facts) { {
+      :concat_basedir         => '/var/lib/puppet/concat',
+      :osfamily               => 'RedHat',
+      :operatingsystemrelease => '7.0',
+    } }
+
+    it { should create_class('openvpn') }
+    it { should_not contain_class('openvpn::service') }
+  end
 
 end

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -357,4 +357,25 @@ describe 'openvpn::server', :type => :define do
 
   end
 
+  context 'systemd enabled distro' do
+    let(:facts) { {
+      :concat_basedir         => '/var/lib/puppet/concat',
+      :osfamily               => 'RedHat',
+      :operatingsystemrelease => '7.0',
+    } }
+
+    let(:params) { {
+      'country'       => 'CO',
+      'province'      => 'ST',
+      'city'          => 'Some City',
+      'organization'  => 'example.org',
+      'email'         => 'testemail@example.org'
+    } }
+
+    it { should contain_service('openvpn@test_server').with(
+      :ensure => 'running',
+      :enable => true,
+    )}
+  end
+
 end


### PR DESCRIPTION
The sysV init script loads all conf files from /etc/openvpn, the systemd service unit file takes a parameter for individual config files.  As a result, non-systemd systems need to support the "old" global service, systemd systems needs to have a service per server defined.

This PR supersedes #125 and can replace #122.  #98 is another possible implementation.