### PR TITLE
normalize config, cleanup ensure_resource

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -114,25 +114,19 @@ define openvpn::ca(
   }
 
   File {
-    group   => $group_to_set,
+    group => $group_to_set,
   }
-
-  # directory shared with openvpn::server
-  ensure_resource(file, "/etc/openvpn/${name}", {
-    ensure  => directory,
-    mode    => '0750',
-  })
 
   exec { "copy easy-rsa to openvpn config folder ${name}":
     command => "/bin/cp -r ${openvpn::params::easyrsa_source} /etc/openvpn/${name}/easy-rsa",
     creates => "/etc/openvpn/${name}/easy-rsa",
-    notify  => Exec["fix_easyrsa_file_permissions_${name}"],
     require => File["/etc/openvpn/${name}"],
   }
 
-  exec { "fix_easyrsa_file_permissions_${name}":
-    refreshonly => true,
-    command     => "/bin/chmod 750 /etc/openvpn/${name}/easy-rsa/*",
+  file { "/etc/openvpn/${name}/easy-rsa":
+    ensure  => directory,
+    mode    => '0750',
+    require => Exec["copy easy-rsa to openvpn config folder ${name}"],
   }
 
   file { "/etc/openvpn/${name}/easy-rsa/revoked":
@@ -143,7 +137,7 @@ define openvpn::ca(
   }
 
   file { "/etc/openvpn/${name}/easy-rsa/vars":
-    ensure  => present,
+    ensure  => file,
     content => template('openvpn/vars.erb'),
     require => Exec["copy easy-rsa to openvpn config folder ${name}"],
   }
@@ -155,7 +149,8 @@ define openvpn::ca(
   if $openvpn::params::link_openssl_cnf == true {
     File["/etc/openvpn/${name}/easy-rsa/openssl.cnf"] {
       ensure => link,
-      target => "/etc/openvpn/${name}/easy-rsa/openssl-1.0.0.cnf"
+      target => "/etc/openvpn/${name}/easy-rsa/openssl-1.0.0.cnf",
+      before => Exec["initca ${name}"],
     }
   }
 
@@ -172,10 +167,7 @@ define openvpn::ca(
     cwd      => "/etc/openvpn/${name}/easy-rsa",
     creates  => "/etc/openvpn/${name}/easy-rsa/keys/ca.key",
     provider => 'shell',
-    require  => [
-      Exec["generate dh param ${name}"],
-      File["/etc/openvpn/${name}/easy-rsa/openssl.cnf"]
-    ],
+    require  => Exec["generate dh param ${name}"],
   }
 
   exec { "generate server cert ${name}":
@@ -192,12 +184,6 @@ define openvpn::ca(
     require => Exec["copy easy-rsa to openvpn config folder ${name}"],
   }
 
-  file { "/etc/openvpn/${name}/crl.pem":
-    mode    => '0640',
-    group   =>  $group_to_set,
-    require => [Exec["create crl.pem on ${name}"], File["/etc/openvpn/${name}"]],
-  }
-
   exec { "create crl.pem on ${name}":
     command  => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out /etc/openvpn/${name}/crl.pem -config /etc/openvpn/${name}/easy-rsa/openssl.cnf",
     cwd      => "/etc/openvpn/${name}/easy-rsa",
@@ -205,6 +191,13 @@ define openvpn::ca(
     provider => 'shell',
     require  => Exec["generate server cert ${name}"],
   }
+
+  file { "/etc/openvpn/${name}/crl.pem":
+    mode    => '0640',
+    group   =>  $group_to_set,
+    require => Exec["create crl.pem on ${name}"],
+  }
+
   if $tls_auth {
     exec { "generate tls key for ${name}":
       command  => 'openvpn --genkey --secret keys/ta.key',

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -198,12 +198,11 @@ define openvpn::client(
   Openvpn::Ca[$ca_name] ->
   Openvpn::Client[$name]
 
-  exec {
-    "generate certificate for ${name} in context of ${ca_name}":
-      command  => ". ./vars && ./pkitool ${name}",
-      cwd      => "/etc/openvpn/${ca_name}/easy-rsa",
-      creates  => "/etc/openvpn/${ca_name}/easy-rsa/keys/${name}.crt",
-      provider => 'shell';
+  exec { "generate certificate for ${name} in context of ${ca_name}":
+    command  => ". ./vars && ./pkitool ${name}",
+    cwd      => "/etc/openvpn/${ca_name}/easy-rsa",
+    creates  => "/etc/openvpn/${ca_name}/easy-rsa/keys/${name}.crt",
+    provider => 'shell';
   }
 
   file { [ "/etc/openvpn/${server}/download-configs/${name}",
@@ -229,6 +228,7 @@ define openvpn::client(
     target  => "/etc/openvpn/${ca_name}/easy-rsa/keys/ca.crt",
     require => Exec["generate certificate for ${name} in context of ${ca_name}"],
   }
+
   if $tls_auth {
     file { "/etc/openvpn/${server}/download-configs/${name}/keys/${name}/ta.key":
       ensure  => link,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,19 +32,17 @@
 class openvpn::config {
 
   if $::osfamily == 'Debian' {
-    concat {
-      '/etc/default/openvpn':
-        owner  => root,
-        group  => root,
-        mode   => 644,
-        warn   => true;
+    concat { '/etc/default/openvpn':
+      owner => root,
+      group => root,
+      mode  => 644,
+      warn  => true;
     }
 
-    concat::fragment {
-      'openvpn.default.header':
-        content => template('openvpn/etc-default-openvpn.erb'),
-        target  => '/etc/default/openvpn',
-        order   => 01;
+    concat::fragment { 'openvpn.default.header':
+      content => template('openvpn/etc-default-openvpn.erb'),
+      target  => '/etc/default/openvpn',
+      order   => 01;
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,8 +40,8 @@ class openvpn {
   Class['openvpn']
 
   if ! $::openvpn::params::systemd {
-    class {'openvpn::service':
-      subscribe => [Class['openvpn::config'], Class['openvpn::install'] ],
+    class { 'openvpn::service':
+      subscribe => [ Class['openvpn::config'], Class['openvpn::install'] ],
       before    => Class['openvpn'],
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,10 +38,8 @@ class openvpn::install inherits openvpn::params {
     ensure_packages( any2array($::openvpn::params::additional_packages) )
   }
 
-
-  file {
-    [ '/etc/openvpn', '/etc/openvpn/keys' ]:
-      ensure  => directory,
-      require => Package['openvpn'];
+  file { [ '/etc/openvpn', '/etc/openvpn/keys' ]:
+    ensure  => directory,
+    require => Package['openvpn'];
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,27 +23,31 @@ class openvpn::params {
 
   case $::osfamily {
     'RedHat': {
-      # Redhat/Centos >= 6.4
-      if(versioncmp($::operatingsystemrelease, '6.4') >= 0) {
+      # Redhat/Centos >= 7.0
+      if(versioncmp($::operatingsystemrelease, '7.0') >= 0) {
         $additional_packages = ['easy-rsa']
         $easyrsa_source = '/usr/share/easy-rsa/2.0'
+        $systemd = true
+
+      # Redhat/Centos >= 6.4
+      } elsif(versioncmp($::operatingsystemrelease, '6.4') >= 0) {
+        $additional_packages = ['easy-rsa']
+        $easyrsa_source = '/usr/share/easy-rsa/2.0'
+        $systemd = false
 
       # Redhat/Centos < 6.4 >= 6
       } elsif(versioncmp($::operatingsystemrelease, '6') >= 0) {
         $easyrsa_source = '/usr/share/openvpn/easy-rsa/2.0'
+        $systemd = false
 
       # Redhat/Centos < 6
       } else {
         $easyrsa_source = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
+        $systemd = false
       }
 
       $ldap_auth_plugin_location = undef # no ldap plugin on redhat/centos
 
-      if(versioncmp($::operatingsystemrelease, '7.0') >= 0) {
-        $systemd = true
-      } else {
-        $systemd = false
-      }
     }
     'Debian': { # Debian/Ubuntu
       case $::lsbdistid {

--- a/manifests/revoke.pp
+++ b/manifests/revoke.pp
@@ -47,7 +47,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-define openvpn::revoke($server) {
+define openvpn::revoke(
+  $server,
+) {
 
   Openvpn::Server[$server] ->
   Openvpn::Revoke[$name]

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -30,11 +30,11 @@
 # limitations under the License.
 #
 class openvpn::service {
-  service {
-    'openvpn':
-      ensure     => running,
-      enable     => true,
-      hasrestart => true,
-      hasstatus  => true;
+
+  service { 'openvpn':
+    ensure     => running,
+    enable     => true,
+    hasrestart => true,
+    hasstatus  => true;
   }
 }


### PR DESCRIPTION
This PR has a lot of changes in it, almost all of them are minor spacing things to try to normalize the spacing between all resources.

The one larger change is to remove the ensure_resource on /etc/openvpn/${name} introduced with the shared_ca merge.  That seemed to be a large hack for a complicated dependency, but looks like it would be something to easily break later.  Needing to define a resource multiple times is usually an indication that something needs to be reworked.

I'm happy to break out any of these into different PRs (or undo any of the changes in this) if desired.