### PR TITLE
refactor to remove ensure_resource

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -198,12 +198,11 @@ define openvpn::client(
   Openvpn::Ca[$ca_name] ->
   Openvpn::Client[$name]
 
-  exec {
-    "generate certificate for ${name} in context of ${ca_name}":
-      command  => ". ./vars && ./pkitool ${name}",
-      cwd      => "/etc/openvpn/${ca_name}/easy-rsa",
-      creates  => "/etc/openvpn/${ca_name}/easy-rsa/keys/${name}.crt",
-      provider => 'shell',
+  exec { "generate certificate for ${name} in context of ${ca_name}":
+    command  => ". ./vars && ./pkitool ${name}",
+    cwd      => "/etc/openvpn/${ca_name}/easy-rsa",
+    creates  => "/etc/openvpn/${ca_name}/easy-rsa/keys/${name}.crt",
+    provider => 'shell';
   }
 
   file { [ "/etc/openvpn/${server}/download-configs/${name}",

--- a/spec/defines/openvpn_ca_spec.rb
+++ b/spec/defines/openvpn_ca_spec.rb
@@ -24,9 +24,11 @@ describe 'openvpn::ca', :type => :define do
     } }
 
     # Files associated with a server config
-    it { should contain_file('/etc/openvpn/test_server/easy-rsa/revoked').
-         with(:ensure =>'directory', :mode =>'0750', :recurse =>true, :group =>'nogroup') }
-    it { should contain_file('/etc/openvpn/test_server/easy-rsa/vars')}
+
+    it { should contain_file('/etc/openvpn/test_server/easy-rsa/clean-all').with(:mode => '0550') }
+    it { should contain_file('/etc/openvpn/test_server/easy-rsa/build-dh').with(:mode => '0550') }
+    it { should contain_file('/etc/openvpn/test_server/easy-rsa/pkitool').with(:mode => '0550') }
+    it { should contain_file('/etc/openvpn/test_server/easy-rsa/vars').with(:mode => '0550') }
     it { should contain_file('/etc/openvpn/test_server/easy-rsa/openssl.cnf').
          with(:recurse =>nil, :group =>'nogroup') }
     it { should contain_file('/etc/openvpn/test_server/easy-rsa/keys/crl.pem').


### PR DESCRIPTION
The ensure_resource shared between server and ca seems like an anti-pattern.  I've refactored that out.