### PR TITLE
pam plugin path customization

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -138,6 +138,9 @@
 #   Boolean, Enable/Disable.
 #   Default: false
 #
+# [*pam_path*]
+#   Default: /usr/lib/openvpn/openvpn-auth-pam.so
+#
 # [*management*]
 #   Boolean.  Enable management interface
 #   Default: false
@@ -367,6 +370,7 @@ define openvpn::server(
   $tcp_nodelay = false,
   $ccd_exclusive = false,
   $pam = false,
+  $pam_path = '/usr/lib/openvpn/openvpn-auth-pam.so',
   $management = false,
   $management_ip = 'localhost',
   $management_port = 7505,

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -97,7 +97,7 @@ tcp-nodelay
 ccd-exclusive
 <% end -%>
 <% if @pam -%>
-plugin /usr/lib/openvpn/openvpn-auth-pam.so login
+plugin <%= @pam_path %> login
 <% end -%>
 <% if @management -%>
 management <%= @management_ip %> <%= @management_port %>


### PR DESCRIPTION
Hi

For x86_64 CentOS systems the openvpn pam plugin path is /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so by default.

I have added a new variable which allows to have a custom path because the default one was for another system, I believe. Maybe this will help somebody in the future.

I have kept the old path as default /usr/lib/openvpn/openvpn-auth-pam.so

Thanks