### PR TITLE
Support for alternate OpenVPN config dir location

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Puppet module to manage OpenVPN servers
 * Support for LDAP-Authentication
 * Support for server instance in client mode
 * Support for TLS
+* Support for OpenVPN configuration directory in alternative location
 
 ## Supported OS
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,11 +9,21 @@
 #   Boolean. Wether the openvpn instances should be started automatically on boot.
 #   Default: true
 #
+# [*config_home*]
+#   String. Directory for OpenVPN configuration files. If set to something other
+#     than "/etc/openvpn" then /etc/openvpn will be created as a symbolic link to
+#     the specified location.
+#   Default: /etc/openvpn
+#
 #
 # === Examples
 #
 #   class { 'openvpn':
 #     autostart_all => true,
+#   }
+#
+#   class { 'openvpn':
+#     config_home => '/home/openvpn',
 #   }
 #
 #
@@ -41,6 +51,7 @@
 #
 class openvpn(
   $autostart_all = true,
+  $config_home = '/etc/openvpn',
 ) {
 
   class { 'openvpn::params': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,7 +39,23 @@ class openvpn::install inherits ::openvpn::params {
   }
 
   file {
-    [ '/etc/openvpn', '/etc/openvpn/keys', '/var/log/openvpn', ]:
+    $::openvpn::config_home:
+      ensure   => directory,
+      require  => Package['openvpn'];
+  }
+
+  if $::openvpn::config_home != '/etc/openvpn' {
+    file {
+      '/etc/openvpn':
+        ensure   => link,
+        force    => true,
+        target   => $::openvpn::config_home,
+        require  => File[$::openvpn::config_home];
+    }
+  }
+
+  file {
+    [ '/etc/openvpn/keys', '/var/log/openvpn', ]:
       ensure  => directory,
       require => Package['openvpn'];
   }


### PR DESCRIPTION
In certain use cases, /etc/openvpn might be on a ephermal file system.
If VPN server cloud instances are being destroyed/re-created, having
the OpenVPN config directory on non-ephermal storage (eg an EBS drive
mounted at /home/openvpn) allows keys and certificates to survive
instance rebuilds.