### PR TITLE
feature (server): add nobind parameter support.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -314,6 +314,10 @@
 #   with client configuration
 #   Default: true
 #
+# [*nobind*]
+#   Boolean. Whether or not to bind to a specific port number.
+#   Default: false
+#
 # [*custom_options*]
 #   Hash of additional options that you want to append to the configuration file.
 #
@@ -426,6 +430,7 @@ define openvpn::server(
   $shared_ca                 = undef,
   $autostart                 = undef,
   $ns_cert_type              = true,
+  $nobind                    = false,
   $custom_options            = {},
 ) {
 

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -237,6 +237,7 @@ describe 'openvpn::server', :type => :define do
       'ping_timer_rem'      => true,
       'tls_auth'            => true,
       'tls_client'          => true,
+      'nobind'              => true,
     } }
 
     let(:facts) { {
@@ -267,6 +268,8 @@ describe 'openvpn::server', :type => :define do
     it { should_not contain_file('/etc/openvpn/test_client.conf').with_content(/^dh/) }
     it { should contain_file('/etc/openvpn/test_client.conf').with_content(%r{^tls-client$}) }
     it { should contain_file('/etc/openvpn/test_client.conf').with_content(%r{^key-direction 1$}) }
+    it { should contain_file('/etc/openvpn/test_client.conf').with_content(%r{^nobind$}) }
+    it { should_not contain_file('/etc/openvpn/test_client.conf').with_content(%r{^port\s+\d+$}) }
 
     it { should_not contain_openvpn__ca('test_client') }
   end

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -27,7 +27,11 @@ proto <%= @proto %>-server
 <% else -%>
 proto <%= @proto %>
 <% end -%>
+<% if @nobind -%>
+nobind
+<% else -%>
 port <%= @port %>
+<% end -%>
 <% if @real_tls_server -%>
 tls-server
 <% end -%>


### PR DESCRIPTION
When the server is running in client mode, you have to specify
a fixed port for every vpn server. Alternativly when you set nobind
openvpn will just pick a random unused port.