### PR TITLE
feature: Add possibilty to not manage the openvpn service with puppet.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@
 # [*autostart_all*]
 #   Boolean. Wether the openvpn instances should be started automatically on boot.
 #   Default: true
+# [*manage_service*]
+#   Boolean. Wether the openvpn service should be managed by puppet.
+#   Default: true
 #
 #
 # === Examples
@@ -41,6 +44,7 @@
 #
 class openvpn(
   $autostart_all = true,
+  $manage_service = true,
 ) {
 
   class { 'openvpn::params': } ->

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -30,10 +30,14 @@
 # limitations under the License.
 #
 class openvpn::service {
-  service { 'openvpn':
-    ensure     => running,
-    enable     => true,
-    hasrestart => true,
-    hasstatus  => true,
+
+  if $manage_service {
+    service { 'openvpn':
+      ensure     => running,
+      enable     => true,
+      hasrestart => true,
+      hasstatus  => true,
+    }
   }
+
 }


### PR DESCRIPTION
When you have redundant pairs of firewalls you sometimes want to use
other means to start/stop the service (i.e. keepalived scripts).