### PR TITLE
feature: Add possibilty to not manage the openvpn service with puppet.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@
 # [*autostart_all*]
 #   Boolean. Wether the openvpn instances should be started automatically on boot.
 #   Default: true
+# [*manage_service*]
+#   Boolean. Wether the openvpn service should be managed by puppet.
+#   Default: true
 #
 #
 # === Examples
@@ -41,6 +44,7 @@
 #
 class openvpn(
   $autostart_all = true,
+  $manage_service = true,
 ) {
 
   class { 'openvpn::params': } ->

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -438,11 +438,16 @@ define openvpn::server(
   Class['openvpn::install'] ->
   Openvpn::Server[$name]
 
-  if $::openvpn::params::systemd {
-    $lnotify = Service["openvpn@${name}"]
-  } else {
-    $lnotify = Service['openvpn']
-    Openvpn::Server[$name] -> Service['openvpn']
+  if $::openvpn::manage_service {
+    if $::openvpn::params::systemd {
+      $lnotify = Service["openvpn@${name}"]
+    } else {
+      $lnotify = Service['openvpn']
+      Openvpn::Server[$name] -> Service['openvpn']
+    }
+  }
+  else {
+    $lnotify = undef
   }
 
   # Selection block to enable or disable tls-server flag
@@ -559,10 +564,12 @@ define openvpn::server(
   }
 
   if $::openvpn::params::systemd {
-    service { "openvpn@${name}":
-      ensure  => running,
-      enable  => true,
-      require => [ File["/etc/openvpn/${name}.conf"], Openvpn::Ca[$ca_name] ]
+    if $::openvpn::manage_service {
+      service { "openvpn@${name}":
+        ensure  => running,
+        enable  => true,
+        require => [ File["/etc/openvpn/${name}.conf"], Openvpn::Ca[$ca_name] ]
+      }
     }
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -30,10 +30,12 @@
 # limitations under the License.
 #
 class openvpn::service {
-  service { 'openvpn':
-    ensure     => running,
-    enable     => true,
-    hasrestart => true,
-    hasstatus  => true,
+  if $::openvpn::manage_service {
+    service { 'openvpn':
+      ensure     => running,
+      enable     => true,
+      hasrestart => true,
+      hasstatus  => true,
+    }
   }
 }

--- a/spec/classes/openvpn_service_spec.rb
+++ b/spec/classes/openvpn_service_spec.rb
@@ -2,7 +2,14 @@ require 'spec_helper'
  
 describe 'openvpn::service', :type => :class do
 
-  let (:facts) { { :concat_basedir => '/var/lib/puppet/concat' } }
+  let (:pre_condition) { 'class { "openvpn": manage_service => true }' }
+  let (:facts) do
+    { 
+      :osfamily => 'Debian',
+      :operatingsystem => 'Debian',
+      :concat_basedir => '/var/lib/puppet/concat',
+    }
+  end
 
   it { should create_class('openvpn::service') }
   it { should contain_service('openvpn').with(


### PR DESCRIPTION
When you have redundant pairs of firewalls you sometimes want to use
other means to start/stop the service (i.e. keepalived scripts).

This is primarly a request for comments. If somebody has a better approach, 
I'd be happy to dig into it.
