### PR TITLE
fix params for old centos/redhat versions

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,28 +20,15 @@ class openvpn::params {
       $group            = 'nobody'
       $link_openssl_cnf = true
       $pam_module_path  = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so'
+      $additional_packages = ['easy-rsa']
+      $easyrsa_source      = '/usr/share/easy-rsa/2.0'
 
       # Redhat/Centos >= 7.0
       if(versioncmp($::operatingsystemrelease, '7.0') >= 0) {
-        $additional_packages = ['easy-rsa']
-        $easyrsa_source      = '/usr/share/easy-rsa/2.0'
-        $systemd             = true
-
-      # Redhat/Centos >= 6.4
-      } elsif(versioncmp($::operatingsystemrelease, '6.4') >= 0) {
-        $additional_packages = ['easy-rsa']
-        $easyrsa_source      = '/usr/share/easy-rsa/2.0'
-        $systemd             = false
-
-      # Redhat/Centos < 6.4 >= 6
-      } elsif(versioncmp($::operatingsystemrelease, '6') >= 0) {
-        $easyrsa_source = '/usr/share/openvpn/easy-rsa/2.0'
-        $systemd        = false
-
-      # Redhat/Centos < 6
+        $systemd = true
+      # Redhat/Centos < 7
       } else {
-        $easyrsa_source = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
-        $systemd        = false
+        $systemd = false
       }
 
       $ldap_auth_plugin_location = undef # no ldap plugin on redhat/centos

--- a/spec/classes/openvpn_install_spec.rb
+++ b/spec/classes/openvpn_install_spec.rb
@@ -49,30 +49,8 @@ describe 'openvpn::install', :type => :class do
 
     context 'redhat/centos' do
       let(:osfamily) { 'RedHat' }
-
-      context '5' do
-        let(:operatingsystemrelease) { '5' }
-        it { should_not contain_package('openvpn-auth-ldap') }
-        it { should_not contain_package('easy-rsa') }
-      end
-
-      context '6.3' do
-        let(:operatingsystemrelease) { '6.3' }
-        it { should_not contain_package('openvpn-auth-ldap') }
-        it { should_not contain_package('easy-rsa') }
-      end
-
-      context '6.4' do
-        let(:operatingsystemrelease) { '6.4' }
-        it { should_not contain_package('openvpn-auth-ldap') }
-        it { should contain_package('easy-rsa') }
-      end
-
-      context '7' do
-        let(:operatingsystemrelease) { '7' }
-        it { should_not contain_package('openvpn-auth-ldap') }
-        it { should contain_package('easy-rsa') }
-      end
+      it { should_not contain_package('openvpn-auth-ldap') }
+      it { should contain_package('easy-rsa') }
     end
 
     context 'Amazon' do

--- a/spec/defines/openvpn_ca_spec.rb
+++ b/spec/defines/openvpn_ca_spec.rb
@@ -98,29 +98,7 @@ describe 'openvpn::ca', :type => :define do
     } }
 
     let(:facts) { { :osfamily => 'RedHat',
-                    :concat_basedir => '/var/lib/puppet/concat',
-                    :operatingsystemmajrelease => 6,
-                    :operatingsystemrelease => '6.4' } }
-
-    context "until version 6.0" do
-      before do
-        facts[:operatingsystemmajrelease] = 5
-        facts[:operatingsystemrelease] = '5.1'
-      end
-      it { should contain_exec('copy easy-rsa to openvpn config folder test_server').with(
-        'command' => '/bin/cp -r /usr/share/doc/openvpn/examples/easy-rsa/2.0 /etc/openvpn/test_server/easy-rsa'
-      )}
-    end
-
-    context "from 6.0 to 6.4" do
-      before do
-        facts[:operatingsystemmajrelease] = 6
-        facts[:operatingsystemrelease] = '6.3'
-      end
-      it { should contain_exec('copy easy-rsa to openvpn config folder test_server').with(
-        'command' => '/bin/cp -r /usr/share/openvpn/easy-rsa/2.0 /etc/openvpn/test_server/easy-rsa'
-      )}
-    end
+                    :concat_basedir => '/var/lib/puppet/concat' } }
 
     it { should contain_package('easy-rsa').with('ensure' => 'present') }
     it { should contain_exec('copy easy-rsa to openvpn config folder test_server').with(

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -327,9 +327,7 @@ describe 'openvpn::server', :type => :define do
     } }
 
     let(:facts) { { :osfamily => 'RedHat',
-                    :concat_basedir => '/var/lib/puppet/concat',
-                    :operatingsystemmajrelease => 6,
-                    :operatingsystemrelease => '6.4' } }
+                    :concat_basedir => '/var/lib/puppet/concat' } }
 
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+nobody$}) }
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so login$}) }


### PR DESCRIPTION
Currently EPEL repository contains the same version of easy-rsa package for all CentOS/RedHat versions:
http://pkgs.org/search/easy-rsa