### PR TITLE
Ubuntu 15.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,8 +58,15 @@ class openvpn::params {
           }
         }
         'Ubuntu': {
+          # Version > 15.04, vivid
+          if(versioncmp($::operatingsystemrelease, '15.04') >= 0){
+            $additional_packages       = ['easy-rsa', 'openvpn-auth-ldap']
+            $easyrsa_source            = '/usr/share/easy-rsa/'
+            $ldap_auth_plugin_location = '/usr/lib/openvpn/openvpn-auth-ldap.so'
+            $systemd                   = true
+
           # Version > 13.10, saucy
-          if(versioncmp($::operatingsystemrelease, '13.10') >= 0) {
+          } elsif(versioncmp($::operatingsystemrelease, '13.10') >= 0) {
             $additional_packages       = ['easy-rsa', 'openvpn-auth-ldap']
             $easyrsa_source            = '/usr/share/easy-rsa/'
             $ldap_auth_plugin_location = '/usr/lib/openvpn/openvpn-auth-ldap.so'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -568,6 +568,7 @@ define openvpn::server(
       service { "openvpn@${name}":
         ensure  => running,
         enable  => true,
+        provider => 'systemd',
         require => [ File["/etc/openvpn/${name}.conf"], Openvpn::Ca[$ca_name] ]
       }
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -36,7 +36,6 @@ class openvpn::service {
       enable     => true,
       hasrestart => true,
       hasstatus  => true,
-      provider => 'systemd'
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -36,6 +36,7 @@ class openvpn::service {
       enable     => true,
       hasrestart => true,
       hasstatus  => true,
+      provider => 'systemd'
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "description": "Puppet module to manage OpenVPN servers",
   "tags": [ "vpn", "openvpn" ],
   "operatingsystem_support": [
-    { "operatingsystem": "Ubuntu", "operatingsystemrelease": ["12.04", "12.10", "13.04", "13.10", "14.04"] },
+    { "operatingsystem": "Ubuntu", "operatingsystemrelease": ["12.04", "12.10", "13.04", "13.10", "14.04", "15.04"] },
     { "operatingsystem": "Debian", "operatingsystemrelease": ["7", "8"] },
     { "operatingsystem": "RedHat", "operatingsystemrelease": ["5", "6", "7"] },
     { "operatingsystem": "CentOS", "operatingsystemrelease": ["5", "6", "7"] },


### PR DESCRIPTION
Some relatively minor adjustments to add compatibility for the recently released Ubuntu 15.04. 
Ubuntu now uses systemd, so have added the appropriate flag in `params.pp`. 

Unfortunately there is an issue in the latest version of puppet (3.7.2 - I think) on Ubuntu 15.04 where it thinks upstart is the default init provider - so have also amended the service resource attribute in `server.pp` accordingly.  While it isn't ideal to manually specify the service provider I don't think it's an issue as it's within a control block to limit the resource only to systemd enabled distributions. 

Please let me know if this needs adjustments, or could be improved. Happy to add tests as necessary but am relatively new to puppet testing so wasn't sure where best to stick them! 

Cheers