### PR TITLE
Fix path to pam module plugin on redhat >= 7

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -198,6 +198,9 @@ define openvpn::client(
   Openvpn::Server[$server] ->
   Openvpn::Client[$name]
 
+  $extca_enabled = getparam(Openvpn::Server[$server], 'extca_enabled')
+  if $extca_enabled { fail('cannot currently create client configs when corresponding openvpn::server is extca_enabled') }
+
   $ca_name = pick($shared_ca, $server)
   Openvpn::Ca[$ca_name] ->
   Openvpn::Client[$name]

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,8 @@ class openvpn::config {
       warn  => true,
     }
 
+    # Template uses:
+    # - $::openvpn::autostart_all
     concat::fragment { 'openvpn.default.header':
       content => template('openvpn/etc-default-openvpn.erb'),
       target  => '/etc/default/openvpn',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 # === Parameters
 #
 # [*autostart_all*]
-#   Boolean. Wether the openvpn instances should be started automatically on boot.
+#   Boolean. Whether openvpn instances should be started automatically on boot.
 #   Default: true
 # [*manage_service*]
 #   Boolean. Wether the openvpn service should be managed by puppet.
@@ -68,17 +68,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-class openvpn(
-  $autostart_all = true,
-  $manage_service = true,
-  $client_defaults = hiera_hash('openvpn::client_defaults', {}),
-  $clients = hiera_hash('openvpn::clients', {}),
+class openvpn (
+  $autostart_all                   = true,
+  $manage_service                  = true,
+  $client_defaults                 = hiera_hash('openvpn::client_defaults', {}),
+  $clients                         = hiera_hash('openvpn::clients', {}),
   $client_specific_config_defaults = hiera_hash('openvpn::client_specific_config_defaults', {}),
-  $client_specific_configs = hiera_hash('openvpn::client_specific_configs', {}),
-  $revoke_defaults = hiera_hash('openvpn::revoke_defaults', {}),
-  $revokes = hiera_hash('openvpn::revokes', {}),
-  $server_defaults = hiera_hash('openvpn::server_defaults', {}),
-  $servers = hiera_hash('openvpn::servers', {}),
+  $client_specific_configs         = hiera_hash('openvpn::client_specific_configs', {}),
+  $revoke_defaults                 = hiera_hash('openvpn::revoke_defaults', {}),
+  $revokes                         = hiera_hash('openvpn::revokes', {}),
+  $server_defaults                 = hiera_hash('openvpn::server_defaults', {}),
+  $servers                         = hiera_hash('openvpn::servers', {}),
 ) {
 
   validate_hash($client_defaults)
@@ -105,7 +105,8 @@ class openvpn(
   }
 
   create_resources('openvpn::client', $clients, $client_defaults)
-  create_resources('openvpn::client_specific_config', $client_specific_configs, $client_specific_config_defaults)
+  create_resources('openvpn::client_specific_config', $client_specific_configs,
+    $client_specific_config_defaults)
   create_resources('openvpn::revoke', $revokes, $revoke_defaults)
   create_resources('openvpn::server', $servers, $server_defaults)
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,7 +31,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-class openvpn::install inherits ::openvpn::params {
+class openvpn::install {
 
   ensure_packages(['openvpn'])
   if $::openvpn::params::additional_packages != undef {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,7 +31,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-class openvpn::install {
+class openvpn::install inherits openvpn::params {
 
   ensure_packages(['openvpn'])
   if $::openvpn::params::additional_packages != undef {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,15 +19,16 @@ class openvpn::params {
     'RedHat': {
       $group = 'nobody'
       $link_openssl_cnf = true
-      $pam_module_path = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so'
       $additional_packages = ['easy-rsa']
       $easyrsa_source = '/usr/share/easy-rsa/2.0'
 
       # Redhat/Centos >= 7.0
       if(versioncmp($::operatingsystemrelease, '7.0') >= 0) {
+        $pam_module_path = '/usr/lib64/openvpn/plugins/openvpn-plugin-auth-pam.so'
         $systemd = true
       # Redhat/Centos < 7
       } else {
+        $pam_module_path = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so'
         $systemd = false
       }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,11 +17,11 @@
 class openvpn::params {
   case $::osfamily {
     'RedHat': {
-      $group            = 'nobody'
+      $group = 'nobody'
       $link_openssl_cnf = true
-      $pam_module_path  = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so'
+      $pam_module_path = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so'
       $additional_packages = ['easy-rsa']
-      $easyrsa_source      = '/usr/share/easy-rsa/2.0'
+      $easyrsa_source = '/usr/share/easy-rsa/2.0'
 
       # Redhat/Centos >= 7.0
       if(versioncmp($::operatingsystemrelease, '7.0') >= 0) {
@@ -42,64 +42,71 @@ class openvpn::params {
         'Debian': {
           # Version > 8.0, jessie
           if(versioncmp($::operatingsystemrelease, '8.0') >= 0) {
-            $additional_packages       = ['easy-rsa', 'openvpn-auth-ldap']
-            $easyrsa_source            = '/usr/share/easy-rsa/'
+            $additional_packages = ['easy-rsa','openvpn-auth-ldap']
+            $easyrsa_source = '/usr/share/easy-rsa/'
             $ldap_auth_plugin_location = '/usr/lib/openvpn/openvpn-auth-ldap.so'
-            $systemd                   = true
+            $systemd = true
 
           # Version > 7.0, wheezy
           } elsif(versioncmp($::operatingsystemrelease, '7.0') >= 0) {
-            $additional_packages       = ['openvpn-auth-ldap']
-            $easyrsa_source            = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
-            $ldap_auth_plugin_location = '/usr/lib/openvpn/openvpn-auth-ldap.so'
-            $systemd                   = false
-          } else {
+            $additional_packages = ['openvpn-auth-ldap']
             $easyrsa_source = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
+            $ldap_auth_plugin_location = '/usr/lib/openvpn/openvpn-auth-ldap.so'
+            $systemd = false
+          } else {
+            $additional_packages = undef
+            $easyrsa_source = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
+            $ldap_auth_plugin_location = undef
+            $systemd = false
           }
         }
         'Ubuntu': {
           # Version > 15.04, vivid
           if(versioncmp($::operatingsystemrelease, '15.04') >= 0){
-            $additional_packages       = ['easy-rsa', 'openvpn-auth-ldap']
-            $easyrsa_source            = '/usr/share/easy-rsa/'
+            $additional_packages = ['easy-rsa','openvpn-auth-ldap']
+            $easyrsa_source = '/usr/share/easy-rsa/'
             $ldap_auth_plugin_location = '/usr/lib/openvpn/openvpn-auth-ldap.so'
-            $systemd                   = true
+            $systemd = true
 
           # Version > 13.10, saucy
           } elsif(versioncmp($::operatingsystemrelease, '13.10') >= 0) {
-            $additional_packages       = ['easy-rsa', 'openvpn-auth-ldap']
-            $easyrsa_source            = '/usr/share/easy-rsa/'
+            $additional_packages = ['easy-rsa','openvpn-auth-ldap']
+            $easyrsa_source = '/usr/share/easy-rsa/'
             $ldap_auth_plugin_location = '/usr/lib/openvpn/openvpn-auth-ldap.so'
-            $systemd                   = false
+            $systemd = false
           } else {
+            $additional_packages = undef
             $easyrsa_source = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
+            $ldap_auth_plugin_location = undef
+            $systemd = false
           }
         }
         default: {
-          fail("Not supported OS / Distribution: ${::osfamily}/${::operatingsystem}")
+          fail("Unsupported OS/Distribution ${::osfamily}/${::operatingsystem}")
         }
       }
     }
     'Archlinux': {
-      $additional_packages       = ['easy-rsa']
-      $easyrsa_source            = '/usr/share/easy-rsa/'
-      $group                     = 'nobody'
+      $additional_packages = ['easy-rsa']
+      $easyrsa_source = '/usr/share/easy-rsa/'
+      $group = 'nobody'
       $ldap_auth_plugin_location = undef # unsupported
-      $link_openssl_cnf          = true
-      $systemd                   = true
+      $link_openssl_cnf = true
+      $systemd = true
     }
     'Linux': {
       case $::operatingsystem {
         'Amazon': {
-          $group               = 'nobody'
+          $group = 'nobody'
           $additional_packages = ['easy-rsa']
-          $easyrsa_source      = '/usr/share/easy-rsa/2.0'
-          $systemd             = false
-          $link_openssl_cnf    = true
-          $pam_module_path     = '/usr/lib/openvpn/openvpn-auth-pam.so'
+          $easyrsa_source = '/usr/share/easy-rsa/2.0'
+          $ldap_auth_plugin_location = undef
+          $systemd = false
+          $link_openssl_cnf = true
+          $pam_module_path = '/usr/lib/openvpn/openvpn-auth-pam.so'
         }
         default: {
-          fail("Not supported OS / Distribution: ${::osfamily}/${::operatingsystem}")
+          fail("Unsupported OS/Distribution ${::osfamily}/${::operatingsystem}")
         }
       }
     }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -149,6 +149,12 @@
 #   Boolean, Enable/Disable.
 #   Default: false
 #
+# [*pam_module_arguments*]
+#    String.  Arguments to pass to the PAM module. For FreeIPA, set this to
+#             "openvpn login USERNAME password PASSWORD" and create HBAC Service
+#             "openvpn".
+#    Default: login
+#
 # [*management*]
 #   Boolean.  Enable management interface
 #   Default: false
@@ -395,6 +401,7 @@ define openvpn::server(
   $tcp_nodelay               = false,
   $ccd_exclusive             = false,
   $pam                       = false,
+  $pam_module_arguments      = 'login',
   $management                = false,
   $management_ip             = 'localhost',
   $management_port           = 7505,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -608,6 +608,7 @@ define openvpn::server(
   # - $ccd_exclusive
   # - $pam
   # - $pam_module_path
+  # - $pam_module_arguments
   # - $management
   # - $management_ip
   # - $management_port

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -317,6 +317,10 @@
 #   String.  Name of a openssl::ca resource to use config with
 #   Default: undef
 #
+# [*crl_verify*]
+#   Boolean. Enable CRL checking. Disabling this is not recommended.
+#   Default: true
+#
 # [*autostart*]
 #   Boolean. Enable autostart for server if openvpn::autostart_all is false.
 #   Default: undef
@@ -441,6 +445,7 @@ define openvpn::server(
   $sndbuf                    = undef,
   $rcvbuf                    = undef,
   $shared_ca                 = undef,
+  $crl_verify                = true,
   $autostart                 = undef,
   $ns_cert_type              = true,
   $nobind                    = false,
@@ -571,6 +576,7 @@ define openvpn::server(
   # - $remote
   # - $ns_cert_type
   # - $server_poll_timeout
+  # - $crl_verify
   # - $ca_name
   # - $ca_common_name
   # - $ssl_key_size

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,15 +1,18 @@
 # == Define: openvpn::server
 #
-# This define creates the openvpn server instance which can run in server or client mode.
+# This define creates the openvpn server instance which can run in server or
+# client mode.
 #
 # === Parameters
 #
 # [*country*]
-#   String.  Country to be used for the SSL certificate, mandatory for server mode.
+#   String.  Country to be used for the SSL certificate,
+#            mandatory for server mode.
 #   Default: undef
 #
 # [*province*]
-#   String.  Province to be used for the SSL certificate, mandatory for server mode.
+#   String.  Province to be used for the SSL certificate,
+#            mandatory for server mode.
 #   Default: undef
 #
 # [*city*]
@@ -17,11 +20,13 @@
 #   Default: undef
 #
 # [*organization*]
-#   String.  Organization to be used for the SSL certificate, mandatory for server mode.
+#   String.  Organization to be used for the SSL certificate,
+#            mandatory for server mode.
 #   Default: undef
 #
 # [*email*]
-#   String.  Email address to be used for the SSL certificate, mandatory for server mode.
+#   String.  Email address to be used for the SSL certificate,
+#            mandatory for server mode.
 #   Default: undef
 #
 # [*remote*]
@@ -84,7 +89,8 @@
 #   Default: "/var/log/openvpn/${name}-status.log"
 #
 # [*status_version*]
-#   Integer. Choose the status file format version number. Can be 1, 2 or 3 and defaults to 1
+#   Integer. Choose the status file format version number.
+#   Can be 1, 2 or 3 and defaults to 1
 #   Default: None (=1)
 #
 # [*server*]
@@ -306,12 +312,12 @@
 #   Default: undef
 #
 # [*autostart*]
-#   Boolean. Enable autostart for this server if openvpn::autostart_all is false.
+#   Boolean. Enable autostart for server if openvpn::autostart_all is false.
 #   Default: undef
 #
 # [*ns_cert_type*]
-#   Boolean. Enable or disable use of ns-cert-type for the session. Generally used
-#   with client configuration
+#   Boolean. Enable or disable use of ns-cert-type for the session. Generally
+#   used with client configuration
 #   Default: true
 #
 # [*nobind*]
@@ -319,7 +325,7 @@
 #   Default: false
 #
 # [*custom_options*]
-#   Hash of additional options that you want to append to the configuration file.
+#   Hash of additional options to append to the configuration file.
 #
 # === Examples
 #
@@ -464,6 +470,7 @@ define openvpn::server(
   }
 
   $pam_module_path = $::openvpn::params::pam_module_path
+  $ldap_auth_plugin_location = $::openvpn::params::ldap_auth_plugin_location
 
   $group_to_set = $group ? {
     false   => $openvpn::params::group,
@@ -489,10 +496,16 @@ define openvpn::server(
   if !$remote {
     if !$shared_ca {
       # VPN Server Mode
-      if $country == undef { fail('country has to be specified in server mode') }
-      if $province == undef { fail('province has to be specified in server mode') }
+      if $country == undef {
+        fail('country has to be specified in server mode')
+      }
+      if $province == undef {
+        fail('province has to be specified in server mode')
+      }
       if $city == undef { fail('city has to be specified in server mode') }
-      if $organization == undef { fail('organization has to be specified in server mode') }
+      if $organization == undef {
+        fail('organization has to be specified in server mode')
+      }
       if $email == undef { fail('email has to be specified in server mode') }
 
       $ca_common_name = $common_name
@@ -546,6 +559,61 @@ define openvpn::server(
     }
   }
 
+  # Template uses:
+  # - $name
+  # - $remote
+  # - $ns_cert_type
+  # - $server_poll_timeout
+  # - $ca_name
+  # - $ca_common_name
+  # - $ssl_key_size
+  # - $proto
+  # - $nobind
+  # - $port
+  # - $real_tls_server
+  # - $tls_auth
+  # - $tls_client
+  # - $compression
+  # - $user
+  # - $group
+  # - $logfile
+  # - $status_log
+  # - $status_version
+  # - $dev
+  # - $local
+  # - $ipp
+  # - $server
+  # - $server_ipv6
+  # - $server_bridge
+  # - $push
+  # - $route
+  # - $route_ipv6
+  # - $sndbuf
+  # - $rcvbuf
+  # - $keepalive
+  # - $topology
+  # - $verb
+  # - $cipher
+  # - $c2c
+  # - $persist_key
+  # - $persist_tun
+  # - $tcp_nodelay
+  # - $ccd_exclusive
+  # - $pam
+  # - $pam_module_path
+  # - $management
+  # - $management_ip
+  # - $management_port
+  # - $up
+  # - $down
+  # - $username_as_common_name
+  # - $ldap_enabled
+  # - $ldap_auth_plugin_location
+  # - $client_cert_not_required
+  # - $duplicate_cn
+  # - $ping_timer_rem
+  # - $fragment
+  # - $custom_options
   file { "/etc/openvpn/${name}.conf":
     owner   => root,
     group   => root,
@@ -566,10 +634,10 @@ define openvpn::server(
   if $::openvpn::params::systemd {
     if $::openvpn::manage_service {
       service { "openvpn@${name}":
-        ensure  => running,
-        enable  => true,
+        ensure   => running,
+        enable   => true,
         provider => 'systemd',
-        require => [ File["/etc/openvpn/${name}.conf"], Openvpn::Ca[$ca_name] ]
+        require  => [ File["/etc/openvpn/${name}.conf"], Openvpn::Ca[$ca_name] ]
       }
     }
   }

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -347,7 +347,7 @@ describe 'openvpn::server', :type => :define do
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so "?login"?$}) }
   end
 
-  context "when RedHat based machine with different pam_module_arguments" do
+  context "when RedHat based machine with different pam_module_arguments and crl_verify disabled" do
     let(:params) { {
       'country'              => 'CO',
       'province'             => 'ST',
@@ -356,12 +356,14 @@ describe 'openvpn::server', :type => :define do
       'email'                => 'testemail@example.org',
       'pam'                  => true,
       'pam_module_arguments' => 'openvpn login USERNAME password PASSWORD',
+      'crl_verify'           => false,
     } }
 
     let(:facts) { { :osfamily => 'RedHat',
                     :concat_basedir => '/var/lib/puppet/concat' } }
 
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so "openvpn login USERNAME password PASSWORD"$}) }
+    it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/^crl-verify/) }
   end
 
   context "when Debian based machine" do

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -344,7 +344,24 @@ describe 'openvpn::server', :type => :define do
                     :concat_basedir => '/var/lib/puppet/concat' } }
 
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+nobody$}) }
-    it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so login$}) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so "?login"?$}) }
+  end
+
+  context "when RedHat based machine with different pam_module_arguments" do
+    let(:params) { {
+      'country'              => 'CO',
+      'province'             => 'ST',
+      'city'                 => 'Some City',
+      'organization'         => 'example.org',
+      'email'                => 'testemail@example.org',
+      'pam'                  => true,
+      'pam_module_arguments' => 'openvpn login USERNAME password PASSWORD',
+    } }
+
+    let(:facts) { { :osfamily => 'RedHat',
+                    :concat_basedir => '/var/lib/puppet/concat' } }
+
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so "openvpn login USERNAME password PASSWORD"$}) }
   end
 
   context "when Debian based machine" do
@@ -360,7 +377,7 @@ describe 'openvpn::server', :type => :define do
     let(:facts) { { :osfamily => 'Debian', :operatingsystem => 'Debian', :concat_basedir => '/var/lib/puppet/concat' } }
 
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^group\s+nogroup$/) }
-    it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib/openvpn/openvpn-auth-pam.so login$}) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib/openvpn/openvpn-auth-pam.so "?login"?$}) }
 
     context 'enabled autostart_all' do
       let(:pre_condition) { 'class { "openvpn": autostart_all => true }' }

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -330,7 +330,7 @@ describe 'openvpn::server', :type => :define do
     it { expect { should compile }.to raise_error }
   end
 
-  context "when RedHat based machine" do
+  context "when RedHat 6.3 based machine" do
     let(:params) { {
       'country'       => 'CO',
       'province'      => 'ST',
@@ -341,10 +341,30 @@ describe 'openvpn::server', :type => :define do
     } }
 
     let(:facts) { { :osfamily => 'RedHat',
+                    :operatingsystemrelease => '6.3',
                     :concat_basedir => '/var/lib/puppet/concat' } }
 
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+nobody$}) }
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so "?login"?$}) }
+  end
+
+  context "when RedHat 7.1.1503 based machine" do
+    let(:params) { {
+      'country'       => 'CO',
+      'province'      => 'ST',
+      'city'          => 'Some City',
+      'organization'  => 'example.org',
+      'email'         => 'testemail@example.org',
+      'pam'           => true,
+    } }
+
+    let(:facts) { { :osfamily => 'RedHat',
+                    :operatingsystemrelease => '7.1.1503',
+                    :concat_basedir => '/var/lib/puppet/concat' } }
+
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+nobody$}) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib64/openvpn/plugins/openvpn-plugin-auth-pam.so "?login"?$}) }
+    it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so}) }
   end
 
   context "when RedHat based machine with different pam_module_arguments and crl_verify disabled" do

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -522,7 +522,7 @@ describe 'openvpn::server', :type => :define do
   end
 
   context "should fail if setting extca_enabled=true without specifying any other extca_* options" do
-    let(:params) { 
+    let(:params) { { 
       'extca_enabled'       => true,
     } }
     it { expect { should compile }.to raise_error }

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -461,6 +461,35 @@ describe 'openvpn::server', :type => :define do
 
   end
 
+  context "RedHat using an external CA and without tls-auth" do
+    let(:params) { {
+      'extca_enabled'           => true,
+      'extca_ca_cert_file'      => '/etc/ipa/ca.crt',
+      'extca_ca_crl_file'       => '/etc/ipa/ca_crl.pem',
+      'extca_server_cert_file'  => '/etc/pki/tls/certs/localhost.crt',
+      'extca_server_key_file'   => '/etc/pki/tls/private/localhost.key',
+      'extca_dh_file'           => '/etc/ipa/dh.pem',
+      'extca_tls_auth_key_file' => '/etc/openvpn/keys/ta.key',
+    } }
+
+    let(:facts) { { :osfamily => 'RedHat',
+                    :concat_basedir => '/var/lib/puppet/concat' } }
+
+    it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/^ca\s+\/etc\/openvpn\/test_server\/keys/) }
+    it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/^crl-verify\s+\/etc\/openvpn\/test_server/) }
+    it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/^cert\s+\/etc\/openvpn\/test_server\/keys/) }
+    it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/^key\s+\/etc\/openvpn\/test_server\/keys/) }
+    it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/^dh\s+\/etc\/openvpn\/test_server\/keys/) }
+    it { should_not contain_file('/etc/openvpn/test_server.conf').with_content(/^tls-auth/) }
+
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^ca\s+\/etc\/ipa\/ca.crt$/) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^crl-verify\s+\/etc\/ipa\/ca_crl.pem$/) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^cert\s+\/etc\/pki\/tls\/certs\/localhost.crt$/) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^key\s+\/etc\/pki\/tls\/private\/localhost.key$/) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^dh\s+\/etc\/ipa\/dh.pem$/) }
+
+  end
+
   context "RedHat using an external CA and enabling tls-auth" do
     let(:params) { {
       'tls_auth'                => true,

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -13,14 +13,26 @@ remote <%= rem %>
 server-poll-timeout <%= @server_poll_timeout %>
 <% end -%>
 <% end -%>
+<% if @extca_enabled -%>
+ca <%= @extca_ca_cert_file %>
+cert <%= @extca_server_cert_file %>
+key <%= @extca_server_key_file %>
+<%   unless @remote or !@extca_dh_file -%>
+dh <%= @extca_dh_file %>
+<%   end -%>
+<%   unless @remote or !@crl_verify or !@extca_ca_crl_file -%>
+crl-verify <%= @extca_ca_crl_file %>
+<%   end -%>
+<% else -%>
 ca /etc/openvpn/<%= @ca_name %>/keys/ca.crt
 cert /etc/openvpn/<%= @ca_name %>/keys/<%= @ca_common_name %>.crt
 key /etc/openvpn/<%= @ca_name %>/keys/<%= @ca_common_name %>.key
-<% unless @remote -%>
+<%   unless @remote -%>
 dh /etc/openvpn/<%= @ca_name %>/keys/dh<%= @ssl_key_size %>.pem
-<% end -%>
-<% unless @remote or !@crl_verify -%>
+<%   end -%>
+<%   unless @remote or !@crl_verify -%>
 crl-verify /etc/openvpn/<%= @ca_name %>/crl.pem
+<%   end -%>
 <% end -%>
 <% if @proto == 'tcp' -%>
 proto <%= @proto %>-server
@@ -139,13 +151,18 @@ duplicate-cn
 ping-timer-rem
 <% end -%>
 <% if @tls_auth -%>
+<%   if @extca_enabled and @extca_tls_auth_key_file -%>
+# tls authentification
+tls-auth <%= @excta_tls_auth_key_file %>
+<%   elsif !@extca_enabled -%>
 # tls authentification
 tls-auth /etc/openvpn/<%= @name %>/keys/ta.key
-<% unless @remote -%>
+<%   end -%>
+<%   unless @remote -%>
 key-direction 0
-<% else -%>
+<%   else -%>
 key-direction 1
-<% end -%>
+<%   end -%>
 <% end -%>
 <% if @fragment != false -%>
 fragment <%= @fragment %>

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -153,7 +153,7 @@ ping-timer-rem
 <% if @tls_auth -%>
 <%   if @extca_enabled and @extca_tls_auth_key_file -%>
 # tls authentification
-tls-auth <%= @excta_tls_auth_key_file %>
+tls-auth <%= @extca_tls_auth_key_file %>
 <%   elsif !@extca_enabled -%>
 # tls authentification
 tls-auth /etc/openvpn/<%= @name %>/keys/ta.key

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -127,7 +127,7 @@ down "<%= @down %>"
 username-as-common-name
 <% end -%>
 <% if @ldap_enabled == true -%>
-plugin <%= scope.lookupvar('::openvpn::params::ldap_auth_plugin_location') %> "/etc/openvpn/<%= name %>/auth/ldap.conf"
+plugin <%= @ldap_auth_plugin_location %> "/etc/openvpn/<%= @name %>/auth/ldap.conf"
 <% end -%>
 <% if @client_cert_not_required -%>
 client-cert-not-required

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -109,7 +109,7 @@ tcp-nodelay
 ccd-exclusive
 <% end -%>
 <% if @pam -%>
-plugin <%= @pam_module_path %> login
+plugin <%= @pam_module_path %> "<%= @pam_module_arguments %>"
 <% end -%>
 <% if @management -%>
 management <%= @management_ip %> <%= @management_port %>

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -19,7 +19,7 @@ key /etc/openvpn/<%= @ca_name %>/keys/<%= @ca_common_name %>.key
 <% unless @remote -%>
 dh /etc/openvpn/<%= @ca_name %>/keys/dh<%= @ssl_key_size %>.pem
 <% end -%>
-<% unless @remote -%>
+<% unless @remote or !@crl_verify -%>
 crl-verify /etc/openvpn/<%= @ca_name %>/crl.pem
 <% end -%>
 <% if @proto == 'tcp' -%>


### PR DESCRIPTION
Looks like the path should be /usr/lib64/openvpn/plugins/openvpn-plugin-auth-pam.so.