### PR TITLE
allow disabling TLS client-side authentication.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -216,6 +216,10 @@
 #   String. LDAP TLS authentication: path to the CA certificates.
 #   Default: None
 #
+# [*ldap_tls_client_auth_enable*]
+#   Boolean. LDAP TLS authentication: Enable if TLS client authentication is required
+#   Default: true
+#
 # [*ldap_tls_client_cert_file*]
 #   String. LDAP TLS authentication: path to the tls client certificate
 #   Default: None
@@ -399,6 +403,7 @@ define openvpn::server(
   $ldap_tls_enable           = false,
   $ldap_tls_ca_cert_file     = '',
   $ldap_tls_ca_cert_dir      = '',
+  $ldap_tls_client_auth_enable = true,
   $ldap_tls_client_cert_file = '',
   $ldap_tls_client_key_file  = '',
   $ca_expire                 = 3650,

--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -9,8 +9,10 @@
   TLSEnable yes
   TLSCACertFile <%= @ldap_tls_ca_cert_file %>
   TLSCACertDir <%= @ldap_tls_ca_cert_dir %>
+<% if @ldap_tls_client_auth_enable -%>
   TLSCertFile <%= @ldap_tls_client_cert_file %>
   TLSKeyFile <%= @ldap_tls_client_key_file %>
+<% end -%>
 <% else %>
   TLSEnable no
 <% end -%>


### PR DESCRIPTION
It should not be mandatory to use client side TLS authentication.
It is very useful to authenticate the LDAP Server (by providing the CA) and encrypt the traffic.

Authenticating the client side adds significant complexity and the client is already authenticating via ldap bind.
This PR allows to disable client side TLS authentication when TLS is in use.

By default it is enabled so that puppet code is backward compatible.
 