### PR TITLE
Use concat for ovpn generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ spec/fixtures
 .gitconfig
 .bundle
 Gemfile.lock
+.idea

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -131,7 +131,7 @@
 #   Boolean.  Enable client to client visibility
 #   Default: false
 #
-# [*tcp-nodelay*]
+# [*tcp_nodelay*]
 #   Boolean, Enable/Disable.
 #   Default: false
 #


### PR DESCRIPTION
Hi,

I refactor the generation of the ovpn file. Its support inline tls-auth now (see https://github.com/luxflux/puppet-openvpn/issues/175).

Concat Module is already required in metdata.json

Tested on Ubuntu 14.04 w/ puppet 3.8.2 and OpenVPN 2.3.7 for Windows (VPN client).

Also, the concat files are located in /var/lib/puppet/concat, which only read read by puppet group and root.

