### PR TITLE
Add parameters to specify custom ca, key and cert files

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -170,7 +170,7 @@ define openvpn::ca(
     provider => 'shell',
     require  => [
       File["${etc_directory}/openvpn/${name}/easy-rsa/vars"],
-      File["${etc_directory}/openvpn/${name}/easy-rsa/keys"]
+      File["${etc_directory}/openvpn/${name}/keys"]
     ]
   }
 

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -163,18 +163,6 @@ define openvpn::ca(
     require => Exec["copy easy-rsa to openvpn config folder ${name}"],
   }
 
-  file { "${etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf":
-    require => Exec["copy easy-rsa to openvpn config folder ${name}"],
-  }
-
-  if $openvpn::params::link_openssl_cnf == true {
-    File["${etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf"] {
-      ensure => link,
-      target => "${etc_directory}/openvpn/${name}/easy-rsa/openssl-1.0.0.cnf",
-      before => Exec["initca ${name}"],
-    }
-  }
-
   exec { "generate dh param ${name}":
     command  => '. ./vars && ./clean-all && ./build-dh',
     cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",
@@ -184,6 +172,19 @@ define openvpn::ca(
   }
 
   if (!$only_dh) {
+
+    file { "${etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf":
+      require => Exec["copy easy-rsa to openvpn config folder ${name}"],
+    }
+
+    if $openvpn::params::link_openssl_cnf == true {
+      File["${etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf"] {
+        ensure => link,
+        target => "${etc_directory}/openvpn/${name}/easy-rsa/openssl-1.0.0.cnf",
+        before => Exec["initca ${name}"],
+      }
+    }
+
     exec { "initca ${name}":
       command  => '. ./vars && ./pkitool --initca',
       cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -1,6 +1,6 @@
 # == Define: openvpn::ca
 #
-# This define creates the openvpn ca and ssl certificates
+# This define creates the openvpn ca and ssl certificates.
 #
 # === Parameters
 #
@@ -58,6 +58,11 @@
 #   Boolean. Determins if a tls key is generated
 #   Default: False
 #
+# [*only_dh*]
+#   Boolean. If true, only build the diffie helman file, not the whole CA stuff.
+#   Should be set to true if you use a custom ca.
+#   Default: false
+#
 # === Examples
 #
 #   openvpn::ca {
@@ -90,11 +95,11 @@
 # limitations under the License.
 #
 define openvpn::ca(
-  $country,
-  $province,
-  $city,
-  $organization,
-  $email,
+  $country      = undef,
+  $province     = undef,
+  $city         = undef,
+  $organization = undef,
+  $email        = undef,
   $common_name  = 'server',
   $group        = false,
   $ssl_key_size = 1024,
@@ -104,9 +109,18 @@ define openvpn::ca(
   $key_name     = '',
   $key_ou       = '',
   $tls_auth     = false,
+  $only_dh      = false
 ) {
 
   include openvpn
+
+  if (!$only_dh) {
+    validate_string($country)
+    validate_string($province)
+    validate_string($city)
+    validate_string($organization)
+    validate_string($email)
+  }
 
   $group_to_set = $group ? {
     false   => $openvpn::params::group,
@@ -169,56 +183,57 @@ define openvpn::ca(
     require  => File["${etc_directory}/openvpn/${name}/easy-rsa/vars"],
   }
 
-  exec { "initca ${name}":
-    command  => '. ./vars && ./pkitool --initca',
-    cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",
-    creates  => "${etc_directory}/openvpn/${name}/easy-rsa/keys/ca.key",
-    provider => 'shell',
-    require  => Exec["generate dh param ${name}"],
-  }
-
-  exec { "generate server cert ${name}":
-    command  => ". ./vars && ./pkitool --server ${common_name}",
-    cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",
-    creates  => "${etc_directory}/openvpn/${name}/easy-rsa/keys/${common_name}.key",
-    provider => 'shell',
-    require  => Exec["initca ${name}"],
-  }
-
-  file { "${etc_directory}/openvpn/${name}/keys":
-    ensure  => link,
-    target  => "${etc_directory}/openvpn/${name}/easy-rsa/keys",
-    require => Exec["copy easy-rsa to openvpn config folder ${name}"],
-  }
-
-  exec { "create crl.pem on ${name}":
-    command  => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out ${etc_directory}/openvpn/${name}/crl.pem -config ${etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf",
-    cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",
-    creates  => "${etc_directory}/openvpn/${name}/crl.pem",
-    provider => 'shell',
-    require  => Exec["generate server cert ${name}"],
-  }
-
-  file { "${etc_directory}/openvpn/${name}/crl.pem":
-    mode    => '0640',
-    group   =>  $group_to_set,
-    require => Exec["create crl.pem on ${name}"],
-  }
-
-  if $tls_auth {
-    exec { "generate tls key for ${name}":
-      command  => 'openvpn --genkey --secret keys/ta.key',
+  if (!$only_dh) {
+    exec { "initca ${name}":
+      command  => '. ./vars && ./pkitool --initca',
       cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",
-      creates  => "${etc_directory}/openvpn/${name}/easy-rsa/keys/ta.key",
+      creates  => "${etc_directory}/openvpn/${name}/easy-rsa/keys/ca.key",
+      provider => 'shell',
+      require  => Exec["generate dh param ${name}"],
+    }
+
+    exec { "generate server cert ${name}":
+      command  => ". ./vars && ./pkitool --server ${common_name}",
+      cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",
+      creates  => "${etc_directory}/openvpn/${name}/easy-rsa/keys/${common_name}.key",
+      provider => 'shell',
+      require  => Exec["initca ${name}"],
+    }
+
+    file { "${etc_directory}/openvpn/${name}/keys":
+      ensure  => link,
+      target  => "${etc_directory}/openvpn/${name}/easy-rsa/keys",
+      require => Exec["copy easy-rsa to openvpn config folder ${name}"],
+    }
+
+    exec { "create crl.pem on ${name}":
+      command  => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out ${etc_directory}/openvpn/${name}/crl.pem -config ${etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf",
+      cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",
+      creates  => "${etc_directory}/openvpn/${name}/crl.pem",
       provider => 'shell',
       require  => Exec["generate server cert ${name}"],
     }
-  }
 
-  file { "${etc_directory}/openvpn/${name}/easy-rsa/keys/crl.pem":
-    ensure  => link,
-    target  => "${etc_directory}/openvpn/${name}/crl.pem",
-    require => Exec["create crl.pem on ${name}"],
-  }
+    file { "${etc_directory}/openvpn/${name}/crl.pem":
+      mode    => '0640',
+      group   =>  $group_to_set,
+      require => Exec["create crl.pem on ${name}"],
+    }
 
+    if $tls_auth {
+      exec { "generate tls key for ${name}":
+        command  => 'openvpn --genkey --secret keys/ta.key',
+        cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",
+        creates  => "${etc_directory}/openvpn/${name}/easy-rsa/keys/ta.key",
+        provider => 'shell',
+        require  => Exec["generate server cert ${name}"],
+      }
+    }
+
+    file { "${etc_directory}/openvpn/${name}/easy-rsa/keys/crl.pem":
+      ensure  => link,
+      target  => "${etc_directory}/openvpn/${name}/crl.pem",
+      require => Exec["create crl.pem on ${name}"],
+    }
+  }
 }

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -168,7 +168,16 @@ define openvpn::ca(
     cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",
     creates  => "${etc_directory}/openvpn/${name}/easy-rsa/keys/dh${ssl_key_size}.pem",
     provider => 'shell',
-    require  => File["${etc_directory}/openvpn/${name}/easy-rsa/vars"],
+    require  => [
+      File["${etc_directory}/openvpn/${name}/easy-rsa/vars"],
+      File["${etc_directory}/openvpn/${name}/easy-rsa/keys"]
+    ]
+  }
+
+  file { "${etc_directory}/openvpn/${name}/keys":
+    ensure  => link,
+    target  => "${etc_directory}/openvpn/${name}/easy-rsa/keys",
+    require => Exec["copy easy-rsa to openvpn config folder ${name}"],
   }
 
   if (!$only_dh) {
@@ -199,12 +208,6 @@ define openvpn::ca(
       creates  => "${etc_directory}/openvpn/${name}/easy-rsa/keys/${common_name}.key",
       provider => 'shell',
       require  => Exec["initca ${name}"],
-    }
-
-    file { "${etc_directory}/openvpn/${name}/keys":
-      ensure  => link,
-      target  => "${etc_directory}/openvpn/${name}/easy-rsa/keys",
-      require => Exec["copy easy-rsa to openvpn config folder ${name}"],
     }
 
     exec { "create crl.pem on ${name}":

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -401,9 +401,9 @@ define openvpn::client(
     }
 
     concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/tls_auth":
-      target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
-      source  => "${etc_directory}/openvpn/${server}/download-configs/${name}/keys/${name}/ta.key",
-      order   => '12'
+      target => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
+      source => "${etc_directory}/openvpn/${server}/download-configs/${name}/keys/${name}/ta.key",
+      order  => '12'
     }
 
     concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/tls_auth_close_tag":

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -322,6 +322,19 @@
 #   Boolean. Whether or not to bind to a specific port number.
 #   Default: false
 #
+# [*ca_path*]
+#   String. Custom path to ca file. If not set, path to ca file will be built
+#   from $ca_name. If provided, all ca_* parameters will be ignored (no ca built).
+#   Default: ''
+#
+# [*key_path*]
+#   String. Custom path to key file. If not set, path to key file will be built from $ca_name and $ca_common_name
+#   Default: ''
+#
+# [*cert_path*]
+#   String. Custom path to cert file. If not set, path to cert file will be built from $ca_name and $ca_common_name
+#   Default: ''
+#
 # [*custom_options*]
 #   Hash of additional options that you want to append to the configuration file.
 #
@@ -436,6 +449,9 @@ define openvpn::server(
   $autostart                 = undef,
   $ns_cert_type              = true,
   $nobind                    = false,
+  $ca_path                   = '',
+  $key_path                  = '',
+  $cert_path                 = '',
   $custom_options            = {},
 ) {
 
@@ -483,6 +499,19 @@ define openvpn::server(
     default => $group
   }
 
+  # Check if custom ca/key/cert have been provided. Either none or all of the 3
+  # parameters must be provided.
+  # Set a $_custom_path var for later checks in the manifest
+  if ($ca_path != '' or $key_path != '' or $cert_path != '') {
+    if ($ca_path == '' or $key_path == '' or $cert_path == '') {
+      fail('Either none or all of the ca_path, key_path and cert_path must be provided')
+    } else {
+      $_custom_path = true
+    }
+  } else {
+    $_custom_path = false
+  }
+
   if $shared_ca {
     $ca_name = $shared_ca
   } else {
@@ -502,11 +531,13 @@ define openvpn::server(
   if !$remote {
     if !$shared_ca {
       # VPN Server Mode
-      if $country == undef { fail('country has to be specified in server mode') }
-      if $province == undef { fail('province has to be specified in server mode') }
-      if $city == undef { fail('city has to be specified in server mode') }
-      if $organization == undef { fail('organization has to be specified in server mode') }
-      if $email == undef { fail('email has to be specified in server mode') }
+      if (!$_custom_path) {
+        if $country == undef { fail('country has to be specified in server mode') }
+        if $province == undef { fail('province has to be specified in server mode') }
+        if $city == undef { fail('city has to be specified in server mode') }
+        if $organization == undef { fail('organization has to be specified in server mode') }
+        if $email == undef { fail('email has to be specified in server mode') }
+      }
 
       $ca_common_name = $common_name
       ::openvpn::ca { $name:
@@ -524,6 +555,7 @@ define openvpn::server(
         key_name     => $key_name,
         key_ou       => $key_ou,
         tls_auth     => $tls_auth,
+        only_dh      => $_custom_path
       }
     } else {
       if !defined(Openvpn::Ca[$shared_ca]) {
@@ -576,13 +608,18 @@ define openvpn::server(
     }
   }
 
+  $_service_require = $_custom_path ? {
+    true    => File["${etc_directory}/openvpn/${name}.conf"],
+    default => [ File["${etc_directory}/openvpn/${name}.conf"], Openvpn::Ca[$ca_name] ]
+  }
+
   if $::openvpn::params::systemd {
     if $::openvpn::manage_service {
       service { "openvpn@${name}":
         ensure   => running,
         enable   => true,
         provider => 'systemd',
-        require  => [ File["${etc_directory}/openvpn/${name}.conf"], Openvpn::Ca[$ca_name] ]
+        require  => $_service_require
       }
     }
   }
@@ -604,7 +641,7 @@ define openvpn::server(
       service { "openvpn_${name}":
         ensure  => running,
         enable  => true,
-        require => [ File["${etc_directory}/openvpn/${name}.conf"], Openvpn::Ca[$ca_name] ]
+        require => $_service_require
       }
     }
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -335,6 +335,10 @@
 #   String. Custom path to cert file. If not set, path to cert file will be built from $ca_name and $ca_common_name
 #   Default: ''
 #
+# [*crl_path*]
+#   String. Custom path to crl file. If not set, path to crl file will be built from $ca_name and $ca_common_name
+#   Default: ''
+#
 # [*custom_options*]
 #   Hash of additional options that you want to append to the configuration file.
 #
@@ -452,6 +456,7 @@ define openvpn::server(
   $ca_path                   = '',
   $key_path                  = '',
   $cert_path                 = '',
+  $crl_path                  = '',
   $custom_options            = {},
 ) {
 
@@ -502,9 +507,9 @@ define openvpn::server(
   # Check if custom ca/key/cert have been provided. Either none or all of the 3
   # parameters must be provided.
   # Set a $_custom_path var for later checks in the manifest
-  if ($ca_path != '' or $key_path != '' or $cert_path != '') {
-    if ($ca_path == '' or $key_path == '' or $cert_path == '') {
-      fail('Either none or all of the ca_path, key_path and cert_path must be provided')
+  if ($ca_path != '' or $key_path != '' or $cert_path != '' or $crl_path != '') {
+    if ($ca_path == '' or $key_path == '' or $cert_path == '' or $crl_path == '') {
+      fail('Either none or all of the ca_path, key_path, cert_path and crl_path must be provided')
     } else {
       $_custom_path = true
     }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -507,10 +507,13 @@ define openvpn::server(
   # Check if custom ca/key/cert have been provided. Either none or all of the 3
   # parameters must be provided.
   # Set a $_custom_path var for later checks in the manifest
-  if ($ca_path != '' or $key_path != '' or $cert_path != '' or $crl_path != '') {
-    if ($ca_path == '' or $key_path == '' or $cert_path == '' or $crl_path == '') {
-      fail('Either none or all of the ca_path, key_path, cert_path and crl_path must be provided')
+  if ($ca_path != '' or $key_path != '' or $cert_path != '') {
+    if ($ca_path == '' or $key_path == '' or $cert_path == '') {
+      fail('Either none or all of the ca_path, key_path, cert_path must be provided')
     } else {
+      if (!$remote and $crl_path == '') {
+        fail('In server mode, crl_path must be provided if you provide other ca_path, key_path and cert_path')
+      }
       $_custom_path = true
     }
   } else {

--- a/spec/defines/openvpn_ca_spec.rb
+++ b/spec/defines/openvpn_ca_spec.rb
@@ -88,6 +88,38 @@ describe 'openvpn::ca', :type => :define do
     it { should contain_exec('generate dh param test_server').with_creates('/etc/openvpn/test_server/easy-rsa/keys/dh2048.pem') }
   end
 
+  context "when generating only DH file" do
+    let(:params) { {
+      'only_dh' => true
+    } }
+
+
+    it { should contain_file('/etc/openvpn/test_server/easy-rsa/clean-all').with(:mode => '0550') }
+    it { should contain_file('/etc/openvpn/test_server/easy-rsa/build-dh').with(:mode => '0550') }
+    it { should contain_file('/etc/openvpn/test_server/easy-rsa/pkitool').with(:mode => '0550') }
+    it { should contain_file('/etc/openvpn/test_server/easy-rsa/vars').with(:mode => '0550') }
+    it { should contain_file('/etc/openvpn/test_server/easy-rsa/openssl.cnf').
+         with(:recurse =>nil, :group =>'nogroup') }
+    it { should_not contain_file('/etc/openvpn/test_server/easy-rsa/keys/crl.pem') }
+    it { should_not contain_file('/etc/openvpn/test_server/keys') }
+
+    # Execs to working with certificates
+    it { should contain_exec('copy easy-rsa to openvpn config folder test_server').with(
+      'command' => '/bin/cp -r /usr/share/doc/openvpn/examples/easy-rsa/2.0 /etc/openvpn/test_server/easy-rsa'
+    )}
+    it { should contain_exec('generate dh param test_server').with_creates('/etc/openvpn/test_server/easy-rsa/keys/dh1024.pem') }
+    it { should_not contain_exec('initca test_server') }
+    it { should_not contain_exec('generate server cert test_server') }
+    it { should_not contain_exec('create crl.pem on test_server') }
+
+    it { should contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(/^export CA_EXPIRE=3650$/) }
+    it { should contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(/^export KEY_EXPIRE=3650$/) }
+    it { should_not contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(/KEY_CN/) }
+    it { should_not contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(/KEY_NAME/) }
+    it { should_not contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(/KEY_OU/) }
+
+  end
+
   context "when RedHat based machine" do
     let(:params) { {
       'country'       => 'CO',

--- a/spec/defines/openvpn_ca_spec.rb
+++ b/spec/defines/openvpn_ca_spec.rb
@@ -100,7 +100,7 @@ describe 'openvpn::ca', :type => :define do
     it { should contain_file('/etc/openvpn/test_server/easy-rsa/vars').with(:mode => '0550') }
     it { should_not contain_file('/etc/openvpn/test_server/easy-rsa/openssl.cnf') }
     it { should_not contain_file('/etc/openvpn/test_server/easy-rsa/keys/crl.pem') }
-    it { should_not contain_file('/etc/openvpn/test_server/keys') }
+    it { should contain_file('/etc/openvpn/test_server/keys') }
 
     # Execs to working with certificates
     it { should contain_exec('copy easy-rsa to openvpn config folder test_server').with(

--- a/spec/defines/openvpn_ca_spec.rb
+++ b/spec/defines/openvpn_ca_spec.rb
@@ -98,8 +98,7 @@ describe 'openvpn::ca', :type => :define do
     it { should contain_file('/etc/openvpn/test_server/easy-rsa/build-dh').with(:mode => '0550') }
     it { should contain_file('/etc/openvpn/test_server/easy-rsa/pkitool').with(:mode => '0550') }
     it { should contain_file('/etc/openvpn/test_server/easy-rsa/vars').with(:mode => '0550') }
-    it { should contain_file('/etc/openvpn/test_server/easy-rsa/openssl.cnf').
-         with(:recurse =>nil, :group =>'nogroup') }
+    it { should_not contain_file('/etc/openvpn/test_server/easy-rsa/openssl.cnf') }
     it { should_not contain_file('/etc/openvpn/test_server/easy-rsa/keys/crl.pem') }
     it { should_not contain_file('/etc/openvpn/test_server/keys') }
 

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -332,6 +332,30 @@ describe 'openvpn::server', :type => :define do
     it { expect { should compile }.to raise_error }
   end
 
+  context "when using bad custom path options" do
+    let(:params) { {
+      'ca_path' => '/tmp/myca.crt'
+    } }
+    it { expect { should compile }.to raise_error }
+  end
+
+  context "when using custom ca & cert paths" do
+    let(:params) { {
+      'ca_path'   => '/tmp/myca.crt',
+      'cert_path' => '/tmp/mycert.crt',
+      'key_path'  => '/tmp/mykey.key'
+    } }
+
+    let(:ca_params) { { 
+      'only_dh' => true
+    } }
+
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^ca\s+\/tmp\/myca.crt$/) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^cert\s+\/tmp\/mycert.crt$/) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^key\s+\/tmp\/mykey.key$/) }
+    it { should contain_openvpn__ca('test_server').with(ca_params) }
+  end
+
   context "when RedHat based machine" do
     let(:params) { {
       'country'       => 'CO',

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -343,16 +343,18 @@ describe 'openvpn::server', :type => :define do
     let(:params) { {
       'ca_path'   => '/tmp/myca.crt',
       'cert_path' => '/tmp/mycert.crt',
-      'key_path'  => '/tmp/mykey.key'
+      'key_path'  => '/tmp/mykey.key',
+      'crl_path'  => '/tmp/mycrl.pem'
     } }
 
-    let(:ca_params) { { 
+    let(:ca_params) { {
       'only_dh' => true
     } }
 
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^ca\s+\/tmp\/myca.crt$/) }
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^cert\s+\/tmp\/mycert.crt$/) }
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^key\s+\/tmp\/mykey.key$/) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^crl\s+\/tmp\/mycrl.pem$/) }
     it { should contain_openvpn__ca('test_server').with(ca_params) }
   end
 

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -354,7 +354,7 @@ describe 'openvpn::server', :type => :define do
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^ca\s+\/tmp\/myca.crt$/) }
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^cert\s+\/tmp\/mycert.crt$/) }
     it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^key\s+\/tmp\/mykey.key$/) }
-    it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^crl\s+\/tmp\/mycrl.pem$/) }
+    it { should contain_file('/etc/openvpn/test_server.conf').with_content(/^crl-verify\s+\/tmp\/mycrl.pem$/) }
     it { should contain_openvpn__ca('test_server').with(ca_params) }
   end
 

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -13,9 +13,15 @@ remote <%= rem %>
 server-poll-timeout <%= @server_poll_timeout %>
 <% end -%>
 <% end -%>
+<% if @_custom_path -%>
+ca <%= @ca_path %>
+cert <%= @cert_path %>
+key <%= @key_path %>
+<% else -%>
 ca <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/ca.crt
 cert <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/<%= @ca_common_name %>.crt
 key <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/<%= @ca_common_name %>.key
+<% end -%>
 <% unless @remote -%>
 dh <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/dh<%= @ssl_key_size %>.pem
 <% end -%>

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -26,7 +26,11 @@ key <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/<%= @ca_common_name %>.k
 dh <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/dh<%= @ssl_key_size %>.pem
 <% end -%>
 <% unless @remote -%>
+<% if @crl_path != '' -%>
+crl-verify <%= @crl_path %>
+<% else -%>
 crl-verify <%= @etc_directory -%>/openvpn/<%= @ca_name %>/crl.pem
+<% end -%>
 <% end -%>
 <% if @proto == 'tcp' -%>
 proto <%= @proto %>-server

--- a/templates/vars.erb
+++ b/templates/vars.erb
@@ -61,11 +61,21 @@ export KEY_EXPIRE=<%= @key_expire %>
 # These are the default values for fields
 # which will be placed in the certificate.
 # Don't leave any of these fields blank.
+<% if @country -%>
 export KEY_COUNTRY="<%= @country %>"
+<% end -%>
+<% if @province -%>
 export KEY_PROVINCE="<%= @province %>"
+<% end -%>
+<% if @city -%>
 export KEY_CITY="<%= @city %>"
+<% end -%>
+<% if @organization -%>
 export KEY_ORG="<%= @organization %>"
+<% end -%>
+<% if @email -%>
 export KEY_EMAIL="<%= @email %>"
+<% end -%>
 <% if @key_cn != '' -%>
 export KEY_CN="<%= @key_cn %>"
 <% end -%>


### PR DESCRIPTION
This PR adds 3 parameters to server class, which enables to use custom ca/key/cert, for exemple to use the ones provided by puppet : https://community.openvpn.net/openvpn/wiki/PuppetCA 