### PR TITLE
[BUGFIX] ldap.erb: use BindDN/Password only if specified

### DIFF
--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -1,7 +1,9 @@
 <LDAP>
   URL <%= @ldap_server %>
+<% if @ldap_binddn != '' and @ldap_bindpass != '' -%>
   BindDN <%= @ldap_binddn %>
   Password <%= @ldap_bindpass %>
+<% end -%>
   Timeout 15
   FollowReferrals no
 


### PR DESCRIPTION
BindDN/Password is required only if your LDAP server does not support anonymous binds. However, if you do not specify those options at all, they end up empty within ldap.conf anyway which leds to the following error while starting the openvpn daemon: "A parse error occured while attempting to comprehend Password, on line 4."