### PR TITLE
Change how .conf and .ovpn files are generated

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -304,7 +304,7 @@ define openvpn::client(
     owner   => root,
     group   => $::openvpn::params::root_group,
     mode    => '0444',
-    content => template('openvpn/client.erb'),
+    content => template('openvpn/client.erb', 'openvpn/client_external_auth.erb'),
   }
 
   exec { "tar the thing ${server} with ${name}":
@@ -326,7 +326,6 @@ define openvpn::client(
     mode    => '0400',
     notify  => Exec["tar the thing ${server} with ${name}"],
     require => [
-      File["${etc_directory}/openvpn/${server}/download-configs/${name}/${name}.conf"],
       File["${etc_directory}/openvpn/${server}/download-configs/${name}/keys/${name}/ca.crt"],
       File["${etc_directory}/openvpn/${server}/download-configs/${name}/keys/${name}/${name}.key"],
       File["${etc_directory}/openvpn/${server}/download-configs/${name}/keys/${name}/${name}.crt"],
@@ -334,14 +333,14 @@ define openvpn::client(
   }
 
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/client_config":
-    target => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
-    source => "${etc_directory}/openvpn/${server}/download-configs/${name}/${name}.conf",
-    order  => '01'
+    target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
+    content => template('openvpn/client.erb'),
+    order   => '01'
   }
 
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/ca_open_tag":
     target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
-    content => "<ca>\n",
+    content => "# Authentication \n<ca>\n",
     order   => '02'
   }
 

--- a/templates/client.erb
+++ b/templates/client.erb
@@ -1,7 +1,4 @@
 client
-ca keys/<%= @name %>/ca.crt
-cert keys/<%= @name %>/<%= @name %>.crt
-key keys/<%= @name %>/<%= @name %>.key
 dev <%= @dev %>
 proto <%= @proto %>
 remote <%= @remote_host %> <%= @port %>
@@ -55,12 +52,6 @@ up "<%= @up %>"
 <% if @down != '' -%>
 down "<%= @down %>"
 <% end -%>
-<% if @tls_auth -%>
-
-# tls authentification
-tls-client
-tls-auth keys/<%= @name %>/ta.key 1
-<% end -%>
 <% if @x509_name -%>
 
 # x509 name verification
@@ -71,3 +62,4 @@ verify-x509-name "<%= @x509_name %>" name
 <% @custom_options.each_pair do |key, value| -%>
 <%= key %> <%= value %>
 <% end -%>
+

--- a/templates/client_external_auth.erb
+++ b/templates/client_external_auth.erb
@@ -1,0 +1,9 @@
+ca keys/<%= @name %>/ca.crt
+cert keys/<%= @name %>/<%= @name %>.crt
+key keys/<%= @name %>/<%= @name %>.key
+<% if @tls_auth -%>
+
+# tls authentification
+tls-client
+tls-auth keys/<%= @name %>/ta.key 1
+<% end -%>


### PR DESCRIPTION
Prior to this, .ovpn would include the .conf file, which means the external references to files were also included.
Now the main template has been split into 2 files: client.erb (included in both .conf and .ovpn) and client_external_auth.erb (included only in .conf)
This should fix issue #187