### PR TITLE
Don't fail if shared_ca directory exist

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -573,11 +573,10 @@ define openvpn::server(
     notify => $lnotify,
   }
   if $shared_ca {
-    file { "${etc_directory}/openvpn/${ca_name}":
+    ensure_resource(file, "${etc_directory}/openvpn/${ca_name}", {
       ensure => directory,
       mode   => '0750',
-      notify => $lnotify,
-    }
+    })
   }
 
   if $extca_enabled {


### PR DESCRIPTION
https://github.com/luxflux/puppet-openvpn/pull/191 ensures
the directory exists but when we use shared_ca, that means we will
declare multiple servers with the same ca. So ensures the directory
exists without failing for redeclaration.