### PR TITLE
allow setting easyrsa_source as param

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -58,6 +58,9 @@
 #   Boolean. Determins if a tls key is generated
 #   Default: False
 #
+# [*easyrsa_source*]
+#   String. Override default easyrsa path
+#
 # === Examples
 #
 #   openvpn::ca {

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -104,6 +104,7 @@ define openvpn::ca(
   $key_name     = '',
   $key_ou       = '',
   $tls_auth     = false,
+  $easyrsa_source = $::openvpn::params::easyrsa_source,
 ) {
 
   include openvpn
@@ -120,7 +121,7 @@ define openvpn::ca(
   $etc_directory = $::openvpn::params::etc_directory
 
   exec { "copy easy-rsa to openvpn config folder ${name}":
-    command => "/bin/cp -r ${openvpn::params::easyrsa_source} ${etc_directory}/openvpn/${name}/easy-rsa",
+    command => "/bin/cp -r ${easyrsa_source} ${etc_directory}/openvpn/${name}/easy-rsa",
     creates => "${etc_directory}/openvpn/${name}/easy-rsa",
     require => File["${etc_directory}/openvpn/${name}"],
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -386,6 +386,9 @@
 # [*custom_options*]
 #   Hash of additional options to append to the configuration file.
 #
+# [*easyrsa_source*]
+#   String. Override default easyrsa path
+#
 # === Examples
 #
 #   openvpn::client {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -509,6 +509,7 @@ define openvpn::server(
   $nobind                    = false,
   $secret                    = undef,
   $custom_options            = {},
+  $easyrsa_source            = $::openvpn::params::easyrsa_source,
 ) {
 
   include openvpn
@@ -606,20 +607,21 @@ define openvpn::server(
 
       $ca_common_name = $common_name
       ::openvpn::ca { $name:
-        country      => $country,
-        province     => $province,
-        city         => $city,
-        organization => $organization,
-        email        => $email,
-        common_name  => $common_name,
-        group        => $group,
-        ssl_key_size => $ssl_key_size,
-        ca_expire    => $ca_expire,
-        key_expire   => $key_expire,
-        key_cn       => $key_cn,
-        key_name     => $key_name,
-        key_ou       => $key_ou,
-        tls_auth     => $tls_auth,
+        country        => $country,
+        province       => $province,
+        city           => $city,
+        organization   => $organization,
+        email          => $email,
+        common_name    => $common_name,
+        group          => $group,
+        ssl_key_size   => $ssl_key_size,
+        ca_expire      => $ca_expire,
+        key_expire     => $key_expire,
+        key_cn         => $key_cn,
+        key_name       => $key_name,
+        key_ou         => $key_ou,
+        tls_auth       => $tls_auth,
+        easyrsa_source => $easyrsa_source,
       }
     } elsif !$extca_enabled {
       if !defined(Openvpn::Ca[$shared_ca]) {


### PR DESCRIPTION
This module only supports default packages for ubuntu.
Between Ubuntu 12 and 13 the modules and easyrsa packages splitted and pathes changed

So we've added a parameter to override this path to get newer packages working.
