### PR TITLE
Fix Unknown variable: '::openvpn::params::namespecific_rclink' on non bsd systems

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,13 +18,14 @@ class openvpn::params {
 
   case $::osfamily {
     'RedHat': {
-      $etc_directory    = '/etc'
-      $root_group       = 'root'
-      $group            = 'nobody'
-      $link_openssl_cnf = true
-      $pam_module_path = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so'
+      $etc_directory       = '/etc'
+      $root_group          = 'root'
+      $group               = 'nobody'
+      $link_openssl_cnf    = true
+      $pam_module_path     = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so'
       $additional_packages = ['easy-rsa']
-      $easyrsa_source = '/usr/share/easy-rsa/2.0'
+      $easyrsa_source      = '/usr/share/easy-rsa/2.0'
+      $namespecific_rclink = false
 
       # Redhat/Centos >= 7.0
       if(versioncmp($::operatingsystemrelease, '7.0') >= 0) and $::operatingsystem != 'Amazon' {
@@ -37,53 +38,54 @@ class openvpn::params {
       $ldap_auth_plugin_location = undef # no ldap plugin on redhat/centos
     }
     'Debian': { # Debian/Ubuntu
-      $etc_directory     = '/etc'
-      $root_group        = 'root'
-      $group             = 'nogroup'
-      $link_openssl_cnf  = true
-      $pam_module_path   = '/usr/lib/openvpn/openvpn-auth-pam.so'
+      $etc_directory       = '/etc'
+      $root_group          = 'root'
+      $group               = 'nogroup'
+      $link_openssl_cnf    = true
+      $pam_module_path     = '/usr/lib/openvpn/openvpn-auth-pam.so'
+      $namespecific_rclink = false
 
       case $::operatingsystem {
         'Debian': {
           # Version > 8.0, jessie
           if(versioncmp($::operatingsystemrelease, '8.0') >= 0) {
-            $additional_packages = ['easy-rsa','openvpn-auth-ldap']
-            $easyrsa_source = '/usr/share/easy-rsa/'
+            $additional_packages       = ['easy-rsa','openvpn-auth-ldap']
+            $easyrsa_source            = '/usr/share/easy-rsa/'
             $ldap_auth_plugin_location = '/usr/lib/openvpn/openvpn-auth-ldap.so'
-            $systemd = true
+            $systemd                   = true
 
           # Version > 7.0, wheezy
           } elsif(versioncmp($::operatingsystemrelease, '7.0') >= 0) {
-            $additional_packages = ['openvpn-auth-ldap']
-            $easyrsa_source = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
+            $additional_packages       = ['openvpn-auth-ldap']
+            $easyrsa_source            = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
             $ldap_auth_plugin_location = '/usr/lib/openvpn/openvpn-auth-ldap.so'
-            $systemd = false
+            $systemd                   = false
           } else {
-            $additional_packages = undef
-            $easyrsa_source = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
+            $additional_packages       = undef
+            $easyrsa_source            = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
             $ldap_auth_plugin_location = undef
-            $systemd = false
+            $systemd                   = false
           }
         }
         'Ubuntu': {
           # Version > 15.04, vivid
           if(versioncmp($::operatingsystemrelease, '15.04') >= 0){
-            $additional_packages = ['easy-rsa','openvpn-auth-ldap']
-            $easyrsa_source = '/usr/share/easy-rsa/'
+            $additional_packages       = ['easy-rsa','openvpn-auth-ldap']
+            $easyrsa_source            = '/usr/share/easy-rsa/'
             $ldap_auth_plugin_location = '/usr/lib/openvpn/openvpn-auth-ldap.so'
-            $systemd = true
+            $systemd                   = true
 
           # Version > 13.10, saucy
           } elsif(versioncmp($::operatingsystemrelease, '13.10') >= 0) {
-            $additional_packages = ['easy-rsa','openvpn-auth-ldap']
-            $easyrsa_source = '/usr/share/easy-rsa/'
+            $additional_packages       = ['easy-rsa','openvpn-auth-ldap']
+            $easyrsa_source            = '/usr/share/easy-rsa/'
             $ldap_auth_plugin_location = '/usr/lib/openvpn/openvpn-auth-ldap.so'
-            $systemd = false
+            $systemd                   = false
           } else {
-            $additional_packages = undef
-            $easyrsa_source = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
+            $additional_packages       = undef
+            $easyrsa_source            = '/usr/share/doc/openvpn/examples/easy-rsa/2.0'
             $ldap_auth_plugin_location = undef
-            $systemd = false
+            $systemd                   = false
           }
         }
         default: {
@@ -98,21 +100,23 @@ class openvpn::params {
       $easyrsa_source            = '/usr/share/easy-rsa/'
       $group                     = 'nobody'
       $ldap_auth_plugin_location = undef # unsupported
-      $link_openssl_cnf = true
-      $systemd = true
+      $link_openssl_cnf          = true
+      $systemd                   = true
+      $namespecific_rclink       = false
     }
     'Linux': {
       case $::operatingsystem {
         'Amazon': {
-          $etc_directory       = '/etc'
-          $root_group          = 'root'
-          $group               = 'nobody'
-          $additional_packages = ['easy-rsa']
-          $easyrsa_source = '/usr/share/easy-rsa/2.0'
+          $etc_directory             = '/etc'
+          $root_group                = 'root'
+          $group                     = 'nobody'
+          $additional_packages       = ['easy-rsa']
+          $easyrsa_source            = '/usr/share/easy-rsa/2.0'
           $ldap_auth_plugin_location = undef
-          $systemd = false
-          $link_openssl_cnf = true
-          $pam_module_path = '/usr/lib/openvpn/openvpn-auth-pam.so'
+          $systemd                   = false
+          $link_openssl_cnf          = true
+          $pam_module_path           = '/usr/lib/openvpn/openvpn-auth-pam.so'
+          $namespecific_rclink       = false
         }
         default: {
           fail("Unsupported OS/Distribution ${::osfamily}/${::operatingsystem}")


### PR DESCRIPTION
After upgrade to 4.0, i have error like there:

```
2016-09-25 14:37:58,973 WARN  [qtp240648626-67] [puppetserver] Puppet Unknown variable: '::openvpn::params::namespecific_rclink'. at /etc/puppetlabs/code/environments/jan/modules/openvpn/manifests/server.pp:518:38
2016-09-25 14:37:59,018 WARN  [qtp240648626-67] [puppetserver] Puppet Unknown variable: '::openvpn::params::namespecific_rclink'. at /etc/puppetlabs/code/environments/jan/modules/openvpn/manifests/server.pp:704:6
```

I simply set namespecific_rclink to false on non bsd systems